### PR TITLE
Removed Apache 2 from the README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,6 @@ Also requires some system services in order to work properly:
   * isc-dhcpd
   * nfs-server
   * tftpd
-  * apache2
   * qemu-img
   * sqlite3
 


### PR DESCRIPTION
* PR type (**Bug Fixing** / **New Feature** / **Enhancement** / **Other?**): Enhancement
* Reference to related issue (issue link): 
* Impact (**Low** / **High** / **Critical** / **Urgent**): Low
* Did you test this PR? Yes
* Brief description of the changes in this PR: Since DRLM now uses the Golang API, the Apache 2 dependency is no longer
needed

