### PR TITLE
After the install, bash completions are sourced

### DIFF
--- a/packaging/debian/postinst
+++ b/packaging/debian/postinst
@@ -43,6 +43,9 @@ case "$1" in
         [ -f /etc/drlm/local.conf ] && echo "DHCP_SVC_NAME=\"isc-dhcp-server\"" >> /etc/drlm/local.conf
         [ -f /etc/drlm/local.conf ] && echo "NFS_SVC_NAME=\"nfs-kernel-server\"" >> /etc/drlm/local.conf
 
+		# Import the bash completions
+		source /etc/bash_completion
+
         ;;
 
     *)

--- a/packaging/rpm/drlm.spec
+++ b/packaging/rpm/drlm.spec
@@ -169,6 +169,8 @@ fi
 ### Save drlm-stord.service
 %{__cp} /usr/sbin/drlm-stord /etc/init.d/tmp_drlm-stord
 %endif
+# Import the bash completions
+source /etc/bash_completion
 
 %preun
 %{__rm} /etc/drlm/cert/drlm.*


### PR DESCRIPTION
* PR type (**Bug Fixing** / **New Feature** / **Enhancement** / **Other?**): Bug Fixing
* Reference to related issue (issue link): #100 
* Impact (**Low** / **High** / **Critical** / **Urgent**): Low
* Did you test this PR? No
* Brief description of the changes in this PR:
Now bash completions are sourced after the install