### PR TITLE
Attempt to fix install error

### DIFF
--- a/packaging/rpm/drlm.spec
+++ b/packaging/rpm/drlm.spec
@@ -200,8 +200,10 @@ chkconfig drlm-stord off
 %{_sbindir}/drlm-api
 
 %posttrans
+if [ -f /etc/drlm/cert/tmp_drlm.key ]; then
 mv /etc/drlm/cert/tmp_drlm.key /etc/drlm/cert/drlm.key
 mv /etc/drlm/cert/tmp_drlm.crt /etc/drlm/cert/drlm.crt
+fi
 
 %if %(ps -p 1 -o comm=) == "systemd"
 mv /etc/systemd/system/tmp_drlm-stord.service /etc/systemd/system/drlm-stord.service


### PR DESCRIPTION
* PR type (**Bug Fixing** / **New Feature** / **Enhancement** / **Other?**): Bug Fixing
* Reference to related issue (issue link): #111 
* Impact (**Low** / **High** / **Critical** / **Urgent**): Low
* Did you test this PR? Yes
* Brief description of the changes in this PR:

When installing the RPM, if it has already been installed, makes a copy
of the keys. After all the installation, it moves them back to the
original name. If it's the first time though, it always tries to move
them back even they don't exist. This commit tries to fix this issue.

