### PR TITLE
wget not required for DRLM server

### DIFF
--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -8,5 +8,5 @@ Package: drlm
 Architecture: all
 Provides: drlm
 Build-Depends: debhelper (>> 5.0.0)
-Depends: openssh-client, openssl, wget, gzip, tar, gawk, sed, grep, coreutils, util-linux, nfs-kernel-server, rpcbind, isc-dhcp-server, tftpd-hpa, qemu-utils, sqlite3, lsb-release, ${shlibs:Depends}, ${misc:Depends}
+Depends: openssh-client, openssl, gzip, tar, gawk, sed, grep, coreutils, util-linux, nfs-kernel-server, rpcbind, isc-dhcp-server, tftpd-hpa, qemu-utils, sqlite3, lsb-release, ${shlibs:Depends}, ${misc:Depends}
 Description: Disaster Recovery Linux Manager

--- a/packaging/rpm/drlm.spec
+++ b/packaging/rpm/drlm.spec
@@ -24,7 +24,7 @@ BuildArch: noarch
 
 ### Dependencies on all distributions
 Requires: openssl
-Requires: wget gzip tar
+Requires: gzip tar
 Requires: gawk sed grep
 Requires: coreutils util-linux
 Requires: rpcbind

--- a/usr/share/drlm/conf/default.conf
+++ b/usr/share/drlm/conf/default.conf
@@ -105,7 +105,6 @@ mkfs.ext2
 mkfs.ext4
 mktemp
 openssl
-wget
 ssh
 sqlite3
 cat


### PR DESCRIPTION
* PR type: Bug Fixing
* Reference to related issue: #127 
* Impact: High
* Did you test this PR? yes
* Brief description of the changes in this PR: deleted package dependencies of wget 

