### PR TITLE
- Completly Reworked NFS configuration #138

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ DRLM make variables (optional):\n\
 clean:
 	rm -f $(name)-$(distversion).tar.gz
 	rm -f build-stamp
-	rm -f packaging/docker/src/drlm*.deb
+	rm -f usr/sbin/drlm-api
 
 validate:
 	@echo -e "\033[1m== Validating scripts and configuration ==\033[0;0m"

--- a/doc/drlm-release-notes.rst
+++ b/doc/drlm-release-notes.rst
@@ -64,6 +64,17 @@ DRLM are compatible with previous versions, unless otherwise noted.
 
 The references pointing to fix #nr or issue #nr refer to our issues tracker
 
+DRLM Version 2.3.2 (April 2020) - Release Notes
+-----------------------------------------------
+  * Fixed wget package dependency (issue #127)
+
+  * Fixed make clean leave drlm-api binary in place (issue #130)
+
+  * Fixed message errors during drlm version upgrade (issue #131, #132)
+
+  * Fixed NFS_OPTS variable is not honored (issue #138)
+  
+
 DRLM Version 2.3.1 (July 2019) - Release Notes
 ----------------------------------------------
   * Fixed DRLM user group permissions (issue #118).
@@ -109,6 +120,7 @@ DRLM Version 2.3.0 (June 2019) - Release Notes
 
   * Installclient workflow install ReaR packages from default.conf by default. Is possible to force to install ReaR from repositories with -r/--repo parameter (issue #114).
 
+
 DRLM Version 2.2.1 (October 2018) - Release Notes
 -------------------------------------------------
 
@@ -142,6 +154,7 @@ DRLM Version 2.2.1 (October 2018) - Release Notes
 
   * Automatically remove DR files after failed backup (issue #90).
 
+
 DRLM Version 2.2.0 (August 2017) - Release Notes
 ------------------------------------------------
 
@@ -163,6 +176,7 @@ DRLM Version 2.2.0 (August 2017) - Release Notes
 
   * Improved treatment of deleted client backups
 
+
 DRLM Version 2.1.3 (May 2017) - Release Notes
 ---------------------------------------------
 
@@ -171,6 +185,7 @@ DRLM Version 2.1.3 (May 2017) - Release Notes
   * Now "apt-get update" is done before "apt-get install" in instclient debian workflow.
 
   * Set global UMASK value for all DRLM creating files durting execution.
+
 
 DRLM Version 2.1.2 (March 2017) - Release Notes
 -----------------------------------------------

--- a/packaging/debian/changelog
+++ b/packaging/debian/changelog
@@ -1,3 +1,11 @@
+drlm (2.3.2) stable release; urgency=high
+  * Fixed wget package dependency (issue #127)
+  * Fixed make clean leave drlm-api binary in place (issue #130)
+  * Fixed message errors during drlm version upgrade (issue #131, #132)
+  * Fixed NFS_OPTS variable is not honored (issue #138)
+
+ -- Pau Roura <pau@brainupdaters.net>  Mon, 06 Apr 2020 00:00:00 +0100
+
 drlm (2.3.1) stable release; urgency=high
   * Fixed DRLM user group permissions (issue #118).
   * Fixed copy_ssh_id function with the -u parameter (issue #119).

--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -8,5 +8,5 @@ Package: drlm
 Architecture: all
 Provides: drlm
 Build-Depends: debhelper (>> 5.0.0)
-Depends: openssh-client, openssl, wget, gzip, tar, gawk, sed, grep, coreutils, util-linux, nfs-kernel-server, rpcbind, isc-dhcp-server, tftpd-hpa, qemu-utils, sqlite3, lsb-release, ${shlibs:Depends}, ${misc:Depends}
+Depends: openssh-client, openssl, gzip, tar, gawk, sed, grep, coreutils, util-linux, nfs-kernel-server, rpcbind, isc-dhcp-server, tftpd-hpa, qemu-utils, sqlite3, lsb-release, ${shlibs:Depends}, ${misc:Depends}
 Description: Disaster Recovery Linux Manager

--- a/packaging/debian/drlm.dsc
+++ b/packaging/debian/drlm.dsc
@@ -1,6 +1,6 @@
 Format: 1.0
 Source: drlm
-Version: 2.3.1
+Version: 2.3.2
 Binary: drlm
 Maintainer: Pau Roura (pau@brainupdaters.net)
 Architecture: all

--- a/packaging/debian/postinst
+++ b/packaging/debian/postinst
@@ -30,6 +30,7 @@ case "$1" in
             if [ $(systemctl --version | head -n 1 | cut -d' ' -f2) -lt 229 ]; then
                 sed -i "s/TimeoutSec=infinity/TimeoutSec=0/g" /etc/systemd/system/drlm-stord.service
             fi
+            systemctl is-active --quiet drlm-stord.service && systemctl stop drlm-stord.service
             systemctl daemon-reload
             systemctl enable drlm-stord.service
             systemctl start drlm-stord.service

--- a/packaging/debian/postinst
+++ b/packaging/debian/postinst
@@ -8,6 +8,9 @@ case "$1" in
         [ ! -d /var/log/drlm/rear ] && mkdir /var/log/drlm/rear
         chmod 775 /var/log/drlm/rear
 
+        #Check /etc/exports.d directory is present
+        [ ! -d /etc/exports.d ] && mkdir /etc/exports.d && chmod 755 /etc/exports.d
+
         #Check if drlm.key has been generated in older installations.
         if [ ! -f /etc/drlm/cert/drlm.key ]; then
             openssl req -newkey rsa:4096 -nodes -keyout /etc/drlm/cert/drlm.key -x509 -days 1825 -subj "/C=ES/ST=CAT/L=GI/O=SA/CN=$(hostname -s)" -out /etc/drlm/cert/drlm.crt

--- a/packaging/rpm/drlm.spec
+++ b/packaging/rpm/drlm.spec
@@ -24,7 +24,7 @@ BuildArch: noarch
 
 ### Dependencies on all distributions
 Requires: openssl
-Requires: wget gzip tar
+Requires: gzip tar
 Requires: gawk sed grep
 Requires: coreutils util-linux
 Requires: rpcbind
@@ -172,16 +172,16 @@ fi
 %endif
 
 %preun
-%{__rm} /etc/drlm/cert/drlm.*
+%{__rm} -f /etc/drlm/cert/drlm.*
 %if "%(ps -p 1 -o comm=)" == "systemd"
-systemctl stop drlm-stord.service
-systemctl disable drlm-stord.service
+systemctl is-active --quiet drlm-stord.service && systemctl stop drlm-stord.service
+systemctl is-enabled --quiet drlm-stord.service && systemctl disable drlm-stord.service
 systemctl daemon-reload
-%{__rm} /etc/systemd/system/drlm-stord.service
+%{__rm} -f /etc/systemd/system/drlm-stord.service
 %else
 service drlm-stord stop
 chkconfig drlm-stord off
-%{__rm} /etc/init.d/drlm-stord
+%{__rm} -f /etc/init.d/drlm-stord
 %endif
 
 %clean
@@ -208,8 +208,9 @@ fi
 
 %if "%(ps -p 1 -o comm=)" == "systemd"
 mv /etc/systemd/system/tmp_drlm-stord.service /etc/systemd/system/drlm-stord.service
+systemctl is-active --quiet drlm-stord.service && systemctl stop drlm-stord.service
 systemctl daemon-reload
-systemctl enable drlm-stord.service
+systemctl is-enabled --quiet drlm-stord.service && systemctl enable drlm-stord.service
 systemctl start drlm-stord.service
 %else
 mv /etc/init.d/tmp_drlm-stord /etc/init.d/drlm-stord
@@ -218,6 +219,12 @@ service drlm-stord start
 %endif
 
 %changelog
+* Mon Apr 06 2020 Pau Roura <pau@brainupdaters.net> 2.3.2
+- Fixed wget package dependency (issue #127)
+- Fixed make clean leave drlm-api binary in place (issue #130)
+- Fixed message errors during drlm version upgrade (issue #131, #132)
+- Fixed NFS_OPTS variable is not honored (issue #138)
+
 * Wed Jul 03 2019 Néfix Estrada <nefix@brainupdaters.net> 2.3.1
 - Fixed DRLM user group permissions (issue #118).
 - Fixed copy_ssh_id function with the -u parameter (issue #119).

--- a/packaging/rpm/drlm.spec
+++ b/packaging/rpm/drlm.spec
@@ -119,6 +119,7 @@ fi
 ### Create logs folder
 mkdir -p /var/log/drlm/rear
 chmod 775 /var/log/drlm/rear
+[ ! -d /etc/exports.d ] && mkdir -p /etc/exports.d && chmod 755 /etc/exports.d
 ### IF IS INSTALL
 if [ "$1" == "1" ]; then
 ### create keys

--- a/usr/sbin/drlm
+++ b/usr/sbin/drlm
@@ -26,7 +26,7 @@
 # Versioning
 PRODUCT="Disaster Recovery Linux Manager"
 PROGRAM=${0##*/}
-VERSION=2.3.1
+VERSION=2.3.2
 RELEASE_DATE="Git"
 
 STARTTIME=$SECONDS

--- a/usr/sbin/drlm-stord
+++ b/usr/sbin/drlm-stord
@@ -35,6 +35,7 @@ source $SHARE_DIR/conf/default.conf
 [ -f /etc/drlm/local.conf ] && source /etc/drlm/local.conf
 source $SHARE_DIR/lib/dbdrv/$DB_BACKEND-driver.sh
 source $SHARE_DIR/lib/backup-functions.sh
+source $SHARE_DIR/lib/nfs-functions.sh
 RETVAL=0
 
 # Only root can start the service
@@ -89,6 +90,15 @@ do_umount_stord() {
 	if [ $? -eq 0 ]; then sleep 1; return 0; else return 1; fi
 }
 
+do_configure_nfs(){
+	configure_nfs_exports
+	reload_nfs
+}
+do_unconfigure_nfs(){
+	unconfigure_nfs_exports
+	reload_nfs
+}
+
 case "$OSTYPE" in
 	RedHat)
 		# Source function library.
@@ -133,6 +143,11 @@ case "$1" in
 					rval=$?
 					[ $rval -ne 0 ] && RETVAL=$rval
 				done
+				echo "Configuring NFS exports" 
+				do_configure_nfs
+				rval=$?
+				[ $rval -ne 0 ] && RETVAL=$rval
+
 				[ $RETVAL -ne 0 ] && exit $RETVAL
 				;;
 
@@ -150,6 +165,10 @@ case "$1" in
 					rval=$?
 					[ $rval -ne 0 ] && RETVAL=$rval
 				done
+				action $"Configuring NFS exports" do_configure_nfs
+				rval=$?
+				[ $rval -ne 0 ] && RETVAL=$rval
+				
 				[ $RETVAL -ne 0 ] && exit $RETVAL
 				;;
 				
@@ -171,6 +190,11 @@ case "$1" in
 					[ $rval -ne 0 ] && RETVAL=$rval
 					log_end_msg $rval
 				done
+				log_begin_msg "Configuring NFS exports"
+				do_configure_nfs
+				rval=$?
+				[ $rval -ne 0 ] && RETVAL=$rval
+				log_end_msg $rval
 				log_daemon_msg "Starting $DESC"
 				[ $RETVAL -ne 0 ] && {
 					log_end_msg $RETVAL
@@ -188,6 +212,10 @@ case "$1" in
 		case "$OSTYPE" in
 			SuSE)
 				echo $"Shutting down $DESC: "
+				echo "Unconfiguring NFS exports" 
+				do_unconfigure_nfs
+				rval=$?
+				[ $rval -ne 0 ] && RETVAL=$rval
 				for lo_dev in $(mount -l |egrep "loop|.dr" | grep -w "ro" | awk '{print $1}')
 				do
 					if [ -z "${lo_dev##*.dr*}" ]; then
@@ -209,6 +237,9 @@ case "$1" in
 
 			RedHat)
 				echo $"Shutting down $DESC: "
+				action $"Unconfiguring NFS exports" do_unconfigure_nfs
+				rval=$?
+				[ $rval -ne 0 ] && RETVAL=$rval
 				for lo_dev in $(mount -l |egrep "loop|.dr"| grep -w "ro" | awk '{print $1}')
 				do
 					if [ -z "${lo_dev##*.dr*}" ]; then
@@ -228,6 +259,11 @@ case "$1" in
 
 			Debian)
 				echo "[....] Stopping $DESC:."
+				log_begin_msg "Unconfiguring NFS exports"
+				do_unconfigure_nfs
+				rval=$?
+				[ $rval -ne 0 ] && RETVAL=$rval
+				log_end_msg $rval
 				for lo_dev in $(mount -l |egrep "loop|.dr"| grep -w "ro" | awk '{print $1}')
 				do
 					if [ -z "${lo_dev##*.dr*}" ]; then

--- a/usr/share/drlm/backup/imp/default/109_enable_client_backup.sh
+++ b/usr/share/drlm/backup/imp/default/109_enable_client_backup.sh
@@ -3,11 +3,11 @@
 Log "$PROGRAM:$WORKFLOW:(ID: ${BKP_ID}):${CLI_NAME}: Enabling DRLM Store for client ...."
 
 if [ -n "$DR_FILE" ]; then
-	if enable_loop_rw ${CLI_ID} ${DR_FILE} ; then
+	if enable_loop_rw ${CLI_ID} ${DR_FILE}; then
 		Log "$PROGRAM:$WORKFLOW:LOOPDEV(${CLI_ID}):ENABLE(ro):DR:${DR_FILE}: .... Success!"
-			if do_mount_ext4_rw ${CLI_ID} ${CLI_NAME} ; then
+			if do_mount_ext4_rw ${CLI_ID} ${CLI_NAME}; then
 				Log "$PROGRAM:$WORKFLOW:FS:MOUNT:LOOPDEV(${CLI_ID}):MNT($STORDIR/$CLI_NAME): .... Success!"
-				if enable_nfs_fs_rw ${CLI_NAME} ; then
+				if enable_nfs_fs_rw ${CLI_NAME}; then
 					Log "$PROGRAM:$WORKFLOW:NFS:ENABLE(ro):$CLI_NAME: .... Success!"
 				else
 					Error "$PROGRAM:$WORKFLOW:NFS:ENABLE (ro):$CLI_NAME: Problem enabling NFS export (ro)! aborting ..."

--- a/usr/share/drlm/backup/mgr/default/059_disable_client_backup.sh
+++ b/usr/share/drlm/backup/mgr/default/059_disable_client_backup.sh
@@ -1,46 +1,55 @@
 # bkpmgr workflow
+function wf_disable_client_backup(){
+   if [ ! -z ${1} ]; then
+      local A_BKP_ID_DB=${1}
+   fi
 
-if disable_nfs_fs ${CLI_NAME} ; then
-   Log "$PROGRAM:$WORKFLOW:NFS:DISABLE:$CLI_NAME: .... Success!"
-else
-   Error "$PROGRAM:$WORKFLOW:NFS:DISABLE:$CLI_NAME: Problem disabling NFS export! aborting ..."
-fi
+   if disable_nfs_fs ${CLI_NAME} ; then
+      Log "$PROGRAM:$WORKFLOW:NFS:DISABLE:$CLI_NAME: .... Success!"
+   else
+      Error "$PROGRAM:$WORKFLOW:NFS:DISABLE:$CLI_NAME: Problem disabling NFS export! aborting ..."
+   fi
 
-if [ -n "$A_BKP_ID_DB" ] ; then
-   Log "$PROGRAM:$WORKFLOW:${CLI_NAME}: Deactivating Backup ${A_BKP_ID_DB} for client: .... "
+   if [ -n "$A_BKP_ID_DB" ] ; then
+      Log "$PROGRAM:$WORKFLOW:${CLI_NAME}: Deactivating Backup ${A_BKP_ID_DB} for client: .... "
 
-   LO_MNT=$(mount -lt ext2,ext4 | grep -w "loop${CLI_ID}" | awk '{ print $3 }'| grep -w "${STORDIR}/${CLI_NAME}")
-   if [ -n "$LO_MNT" ]; then
-      if do_umount ${CLI_ID} ; then
-         Log "$PROGRAM:$WORKFLOW:FS:UMOUNT:LOOPDEV(${CLI_ID}):MNT($STORDIR/$CLI_NAME): .... Success!"
-      else
-         Error "$PROGRAM:$WORKFLOW:FS:UMOUNT:LOOPDEV(${CLI_ID}):MNT($STORDIR/$CLI_NAME): Problem unmounting Filesystem! aborting ..."
+      LO_MNT=$(mount -lt ext2,ext4 | grep -w "loop${CLI_ID}" | awk '{ print $3 }'| grep -w "${STORDIR}/${CLI_NAME}")
+      if [ -n "$LO_MNT" ]; then
+         if do_umount ${CLI_ID} ; then
+            Log "$PROGRAM:$WORKFLOW:FS:UMOUNT:LOOPDEV(${CLI_ID}):MNT($STORDIR/$CLI_NAME): .... Success!"
+         else
+            Error "$PROGRAM:$WORKFLOW:FS:UMOUNT:LOOPDEV(${CLI_ID}):MNT($STORDIR/$CLI_NAME): Problem unmounting Filesystem! aborting ..."
+         fi
       fi
+
+      if disable_loop ${CLI_ID} ; then
+         Log "$PROGRAM:$WORKFLOW:LOOPDEV(${CLI_ID}):DISABLE:$CLI_NAME: .... Success!"
+      else
+         Error "$PROGRAM:$WORKFLOW:LOOPDEV(${CLI_ID}):DISABLE:$CLI_NAME: Problem disabling Loop Device! aborting ..."
+      fi
+
+      #Disable backup from database
+      if disable_backup_db ${A_BKP_ID_DB} ; then
+         Log "$PROGRAM:$WORKFLOW:MODE:perm:DB:disable:(ID: ${A_BKP_ID}):${CLI_NAME}: .... Success!"
+      else
+         Error "$PROGRAM:$WORKFLOW:MODE:perm:DB:disable:(ID: ${A_BKP_ID}):${CLI_NAME}: Problem disabling backup in database! aborting ..."
+      fi
+
+      Log "$PROGRAM:$WORKFLOW:${CLI_NAME}: Deactivating previous DR store for client: .... Success!"
    fi
+}
 
-   if disable_loop ${CLI_ID} ; then
-      Log "$PROGRAM:$WORKFLOW:LOOPDEV(${CLI_ID}):DISABLE:$CLI_NAME: .... Success!"
-   else
-      Error "$PROGRAM:$WORKFLOW:LOOPDEV(${CLI_ID}):DISABLE:$CLI_NAME: Problem disabling Loop Device! aborting ..."
-   fi
-
-   #Disable backup from database
-   if disable_backup_db ${A_BKP_ID_DB} ; then
-      Log "$PROGRAM:$WORKFLOW:MODE:perm:DB:disable:(ID: ${A_BKP_ID}):${CLI_NAME}: .... Success!"
-   else
-      Error "$PROGRAM:$WORKFLOW:MODE:perm:DB:disable:(ID: ${A_BKP_ID}):${CLI_NAME}: Problem disabling backup in database! aborting ..."
-   fi
-
-   Log "$PROGRAM:$WORKFLOW:${CLI_NAME}: Deactivating previous DR store for client: .... Success!"
-fi
-
-if [ "$DISABLE" == "yes" ]; then
-   #if enable_nfs_fs_rw ${CLI_NAME} ; then
-   #   Log "$PROGRAM:$WORKFLOW:NFS:ENABLE (rw):$CLI_NAME: .... Success!"
-   #else
-   #   Error "$PROGRAM:$WORKFLOW:NFS:ENABLE (rw):$CLI_NAME: Problem enabling NFS export (rw)! aborting ..."
-   #fi
-
+if [[ ${DISABLE} == 'yes' ]]; then
+   wf_disable_client_backup
    Log "$PROGRAM:$WORKFLOW:${CLI_NAME}: Deactivating Backup ${A_BKP_ID_DB} for client: .... Success!"
    exit 0
+fi
+if [[ ${ENABLE} == 'yes' ]]; then
+   local A_BKP_ID_DB_OLD=$(get_active_cli_bkp_from_db_dbdrv ${CLI_NAME})
+   if wf_disable_client_backup ${A_BKP_ID_DB_OLD} ; then
+      Log "$PROGRAM:$WORKFLOW:${CLI_NAME}: Deactivating Backup ${A_BKP_ID_DB} for client: .... Success!"
+      return 0
+   else
+      return 1
+   fi
 fi

--- a/usr/share/drlm/backup/mgr/default/059_disable_client_backup.sh
+++ b/usr/share/drlm/backup/mgr/default/059_disable_client_backup.sh
@@ -24,7 +24,7 @@ if [ -n "$A_BKP_ID_DB" ] ; then
       Error "$PROGRAM:$WORKFLOW:LOOPDEV(${CLI_ID}):DISABLE:$CLI_NAME: Problem disabling Loop Device! aborting ..."
    fi
 
-   #Disable backaup from database
+   #Disable backup from database
    if disable_backup_db ${A_BKP_ID_DB} ; then
       Log "$PROGRAM:$WORKFLOW:MODE:perm:DB:disable:(ID: ${A_BKP_ID}):${CLI_NAME}: .... Success!"
    else
@@ -35,11 +35,11 @@ if [ -n "$A_BKP_ID_DB" ] ; then
 fi
 
 if [ "$DISABLE" == "yes" ]; then
-   if enable_nfs_fs_rw ${CLI_NAME} ; then
-      Log "$PROGRAM:$WORKFLOW:NFS:ENABLE (rw):$CLI_NAME: .... Success!"
-   else
-      Error "$PROGRAM:$WORKFLOW:NFS:ENABLE (rw):$CLI_NAME: Problem enabling NFS export (rw)! aborting ..."
-   fi
+   #if enable_nfs_fs_rw ${CLI_NAME} ; then
+   #   Log "$PROGRAM:$WORKFLOW:NFS:ENABLE (rw):$CLI_NAME: .... Success!"
+   #else
+   #   Error "$PROGRAM:$WORKFLOW:NFS:ENABLE (rw):$CLI_NAME: Problem enabling NFS export (rw)! aborting ..."
+   #fi
 
    Log "$PROGRAM:$WORKFLOW:${CLI_NAME}: Deactivating Backup ${A_BKP_ID_DB} for client: .... Success!"
    exit 0

--- a/usr/share/drlm/backup/mgr/default/059_disable_client_backup.sh
+++ b/usr/share/drlm/backup/mgr/default/059_disable_client_backup.sh
@@ -1,4 +1,5 @@
 # bkpmgr workflow
+
 function wf_disable_client_backup(){
    if [ ! -z ${1} ]; then
       local A_BKP_ID_DB=${1}

--- a/usr/share/drlm/backup/mgr/default/109_enable_client_backup.sh
+++ b/usr/share/drlm/backup/mgr/default/109_enable_client_backup.sh
@@ -1,32 +1,34 @@
 # bkpmgr workflow
+if [[ ${ENABLE} = 'yes' ]]; then
+    Log "$PROGRAM:$WORKFLOW:(ID: ${BKP_ID}):${CLI_NAME}: Enabling DRLM Store for client ...."
 
-Log "$PROGRAM:$WORKFLOW:(ID: ${BKP_ID}):${CLI_NAME}: Enabling DRLM Store for client ...."
+    DR_FILE=$(get_backup_drfile "$BKP_ID")
 
-DR_FILE=$(get_backup_drfile "$BKP_ID")
+    if [ -n "$DR_FILE" ]; then
 
-if [ -n "$DR_FILE" ]; then
-
-    if enable_loop_rw ${CLI_ID} ${DR_FILE} ; then
-        Log "$PROGRAM:$WORKFLOW:LOOPDEV(${CLI_ID}):ENABLE(ro):DR:${DR_FILE}: .... Success!"
-        if do_mount_ext4_ro ${CLI_ID} ${CLI_NAME} ; then
-         Log "$PROGRAM:$WORKFLOW:FS:MOUNT:LOOPDEV(${CLI_ID}):MNT($STORDIR/$CLI_NAME): .... Success!"
-            if enable_nfs_fs_ro ${CLI_NAME} ; then
-                Log "$PROGRAM:$WORKFLOW:NFS:ENABLE(ro):$CLI_NAME: .... Success!"
+        if enable_loop_rw ${CLI_ID} ${DR_FILE} ; then
+            Log "$PROGRAM:$WORKFLOW:LOOPDEV(${CLI_ID}):ENABLE(ro):DR:${DR_FILE}: .... Success!"
+            if do_mount_ext4_ro ${CLI_ID} ${CLI_NAME} ; then
+            Log "$PROGRAM:$WORKFLOW:FS:MOUNT:LOOPDEV(${CLI_ID}):MNT($STORDIR/$CLI_NAME): .... Success!"
+                if enable_nfs_fs_ro ${CLI_NAME} ; then
+                    Log "$PROGRAM:$WORKFLOW:NFS:ENABLE(ro):$CLI_NAME: .... Success!"
+                else
+                    Error "$PROGRAM:$WORKFLOW:NFS:ENABLE (ro):$CLI_NAME: Problem enabling NFS export (ro)! aborting ..."
+                fi
             else
-                Error "$PROGRAM:$WORKFLOW:NFS:ENABLE (ro):$CLI_NAME: Problem enabling NFS export (ro)! aborting ..."
+                Error "$PROGRAM:$WORKFLOW:FS:MOUNT:LOOPDEV(${CLI_ID}):MNT(${STORDIR}/${CLI_NAME}): Problem mounting Filesystem!"
             fi
         else
-            Error "$PROGRAM:$WORKFLOW:FS:MOUNT:LOOPDEV(${CLI_ID}):MNT(${STORDIR}/${CLI_NAME}): Problem mounting Filesystem!"
+            Error "$PROGRAM:$WORKFLOW:LOOPDEV(${CLI_ID}):ENABLE(ro):DR:${DR_FILE}: Problem enabling Loop Device (ro)!"
         fi
-    else
-        Error "$PROGRAM:$WORKFLOW:LOOPDEV(${CLI_ID}):ENABLE(ro):DR:${DR_FILE}: Problem enabling Loop Device (ro)!"
+
+        if enable_backup_db ${BKP_ID} ; then
+            Log "$PROGRAM:$WORKFLOW:MODE:perm:DB:enable:(ID: ${BKP_ID}):${CLI_NAME}: .... Success!"
+        else
+            Error "$PROGRAM:$WORKFLOW:MODE:perm:DB:enable:(ID: ${BKP_ID}):${CLI_NAME}: Problem enabling backup in database! aborting ..."
+        fi
     fi
 
-    if enable_backup_db ${BKP_ID} ; then
-        Log "$PROGRAM:$WORKFLOW:MODE:perm:DB:enable:(ID: ${BKP_ID}):${CLI_NAME}: .... Success!"
-    else
-        Error "$PROGRAM:$WORKFLOW:MODE:perm:DB:enable:(ID: ${BKP_ID}):${CLI_NAME}: Problem enabling backup in database! aborting ..."
-    fi
+    Log "$PROGRAM:$WORKFLOW:(ID: ${BKP_ID}):${CLI_NAME}: Enabling DRLM Store for client .... Success!"
+
 fi
-
-Log "$PROGRAM:$WORKFLOW:(ID: ${BKP_ID}):${CLI_NAME}: Enabling DRLM Store for client .... Success!"

--- a/usr/share/drlm/backup/run/default/079_create_enable_dr_img.sh
+++ b/usr/share/drlm/backup/run/default/079_create_enable_dr_img.sh
@@ -30,8 +30,7 @@ fi
 
 # Format loopdev:
 
-if do_format_ext4 ${CLI_ID} ;
-then
+if do_format_ext4 ${CLI_ID}; then
 	Log "$PROGRAM:$WORKFLOW:genimage:MKFS:ext4:LOOPDEV(${CLI_ID}): .... Success!"
 else
         report_error "ERROR:$PROGRAM:$WORKFLOW:genimage:MKFS:ext4:LOOPDEV(${CLI_ID}): Problem Formating device (ext4)! aborting ..."
@@ -40,16 +39,14 @@ fi
 
 # Mount image:
 
-if do_mount_ext4_rw ${CLI_ID} ${CLI_NAME};
-then
+if do_mount_ext4_rw ${CLI_ID} ${CLI_NAME}; then
 	Log "$PROGRAM:$WORKFLOW:genimage:FS:MOUNT:LOOPDEV(${CLI_ID}):MNT($STORDIR/$CLI_NAME): .... Success!"
 else
 	report_error "ERROR:$PROGRAM:$WORKFLOW:genimage:FS:MOUNT:LOOPDEV(${CLI_ID}):MNT(${STORDIR}/${CLI_NAME}): Problem mounting Filesystem (rw)! aborting ..."
 	Error "$PROGRAM:$WORKFLOW:genimage:FS:MOUNT:LOOPDEV(${CLI_ID}):MNT(${STORDIR}/${CLI_NAME}): Problem mounting Filesystem (rw)! aborting ..."
 fi
 
-if enable_nfs_fs_rw ${CLI_NAME} ;
-then
+if enable_nfs_fs_rw ${CLI_NAME}; then
 	Log "$PROGRAM:$WORKFLOW:genimage:NFS:ENABLE(rw):$CLI_NAME: .... Success!"
 else
 	report_error "ERROR:$PROGRAM:$WORKFLOW:genimage:NFS:ENABLE (rw):$CLI_NAME: Problem enabling NFS export (rw)! aborting ..."

--- a/usr/share/drlm/backup/run/default/109_run_client_backup.sh
+++ b/usr/share/drlm/backup/run/default/109_run_client_backup.sh
@@ -3,8 +3,7 @@ Log "Starting remote DR backup on client: ${CLI_NAME} ..."
 
 BKP_DURATION=$(date +%s)
 
-if OUT=$(run_mkbackup_ssh_remote $CLI_ID) ;
-then
+if OUT=$(run_mkbackup_ssh_remote $CLI_ID); then
 	#Getting the backup duration in seconds 
 	BKP_DURATION=$(echo "$(($(date +%s) - $BKP_DURATION))")
 	#From seconds to hours:minuts:seconds
@@ -19,30 +18,26 @@ else
 	Log "$PROGRAM:$WORKFLOW:REMOTE:mkbackup:$CLI_NAME: Starting rollback to previous DR ...."
 	#report_error "$PROGRAM:$WORKFLOW:REMOTE:mkbackup:$CLI_NAME: Starting rollback to previous DR ...."
 
-	if disable_nfs_fs ${CLI_NAME} ;
-	then
-    		Log "$PROGRAM:$WORKFLOW:REMOTE:mkbackup:ROLLBACK:NFS:DISABLE:$CLI_NAME: .... Success!"
-    		if do_umount ${CLI_ID} ;
-    		then
-    			Log "$PROGRAM:$WORKFLOW:REMOTE:mkbackup:ROLLBACK:FS:UMOUNT:LOOPDEV(${CLI_ID}):MNT($STORDIR/$CLI_NAME): .... Success!"
-    			if disable_loop ${CLI_ID} ;
-    			then
-    				Log "$PROGRAM:$WORKFLOW:REMOTE:mkbackup:ROLLBACK:LOOPDEV(${CLI_ID}):DISABLE:DR:${DR_FILE}: .... Success!"
+	if disable_nfs_fs ${CLI_NAME}; then
+    	Log "$PROGRAM:$WORKFLOW:REMOTE:mkbackup:ROLLBACK:NFS:DISABLE:$CLI_NAME: .... Success!"
+    	if do_umount ${CLI_ID}; then
+    		Log "$PROGRAM:$WORKFLOW:REMOTE:mkbackup:ROLLBACK:FS:UMOUNT:LOOPDEV(${CLI_ID}):MNT($STORDIR/$CLI_NAME): .... Success!"
+    		if disable_loop ${CLI_ID}; then
+    			Log "$PROGRAM:$WORKFLOW:REMOTE:mkbackup:ROLLBACK:LOOPDEV(${CLI_ID}):DISABLE:DR:${DR_FILE}: .... Success!"
 			else
-        			Log "$PROGRAM:$WORKFLOW:REMOTE:mkbackup:ROLLBACK:LOOPDEV(${CLI_ID}):DISABLE:DR:${DR_FILE}: Problem disabling Loop device!"
-        			ROLL_ERR=1
-    			fi
-		else
-    	    		Log "$PROGRAM:$WORKFLOW:REMOTE:mkbackup:ROLLBACK:FS:UMOUNT:LOOPDEV(${CLI_ID}):MNT($STORDIR/$CLI_NAME): Problem umounting Filesystem!"
-    	    	ROLL_ERR=1
+        		Log "$PROGRAM:$WORKFLOW:REMOTE:mkbackup:ROLLBACK:LOOPDEV(${CLI_ID}):DISABLE:DR:${DR_FILE}: Problem disabling Loop device!"
+        		ROLL_ERR=1
     		fi
-	else
-        	Log "$PROGRAM:$WORKFLOW:REMOTE:mkbackup:ROLLBACK:NFS:DISABLE:$CLI_NAME: Problem disabling NFS export!"
-        	ROLL_ERR=1
+		else
+    	   		Log "$PROGRAM:$WORKFLOW:REMOTE:mkbackup:ROLLBACK:FS:UMOUNT:LOOPDEV(${CLI_ID}):MNT($STORDIR/$CLI_NAME): Problem umounting Filesystem!"
+    	   	ROLL_ERR=1
     	fi
+	else
+       	Log "$PROGRAM:$WORKFLOW:REMOTE:mkbackup:ROLLBACK:NFS:DISABLE:$CLI_NAME: Problem disabling NFS export!"
+       	ROLL_ERR=1
+    fi
 
-	if [ $ROLL_ERR -eq 0 ];
-	then	
+	if [ $ROLL_ERR -eq 0 ];	then	
 		rm -vf ${ARCHDIR}/${DR_FILE}
 		if [ $? -eq 0 ]; then 
 			Log "$PROGRAM:$WORKFLOW:REMOTE:mkbackup:ROLLBACK:CLEAN:${ARCHDIR}/${DR_FILE}: .... Success!"	
@@ -53,14 +48,11 @@ else
 	fi
 
 	if [[ -n "$A_DR_FILE" && $ROLL_ERR -eq 0 ]]; then
-		if enable_loop_rw ${CLI_ID} $(basename ${A_DR_FILE}) ;
-		then
+		if enable_loop_rw ${CLI_ID} $(basename ${A_DR_FILE}); then
 			Log "$PROGRAM:$WORKFLOW:REMOTE:mkbackup:ROLLBACK:LOOPDEV(${CLI_ID}):ENABLE:DR:${A_DR_FILE}: .... Success!"
-			if do_mount_ext4_ro ${CLI_ID} ${CLI_NAME} ;
-			then
+			if do_mount_ext4_ro ${CLI_ID} ${CLI_NAME}; then
 				Log "$PROGRAM:$WORKFLOW:REMOTE:mkbackup:ROLLBACK:FS:MOUNT:LOOPDEV(${CLI_ID}):MNT($STORDIR/$CLI_NAME): .... Success!"
-				if enable_nfs_fs_ro ${CLI_NAME} ;
-				then
+				if enable_nfs_fs_ro ${CLI_NAME}; then
 					Log "$PROGRAM:$WORKFLOW:REMOTE:mkbackup:ROLLBACK:NFS:ENABLE(ro):$CLI_NAME: .... Success!"
 				else
 					Log "$PROGRAM:$WORKFLOW:REMOTE:mkbackup:ROLLBACK:NFS:ENABLE(ro):$CLI_NAME: Problem enabling NFS export!"

--- a/usr/share/drlm/backup/run/default/129_post_backup_tasks.sh
+++ b/usr/share/drlm/backup/run/default/129_post_backup_tasks.sh
@@ -47,11 +47,9 @@ Log "$PROGRAM:$WORKFLOW:postbackup:${CLI_NAME}: Fixing PXE permissions for DR im
 
 Log "$PROGRAM:$WORKFLOW:postbackup:${CLI_NAME}: Enabling DRLM Store ..."
 
-	if do_remount ro ${CLI_ID} ${CLI_NAME} ;
-	then
+	if do_remount ro ${CLI_ID} ${CLI_NAME};	then
 		Log "$PROGRAM:$WORKFLOW:postbackup:FS:MOUNT:LOOPDEV(${CLI_ID}):MNT($STORDIR/$CLI_NAME): ... Success!"
-		if enable_nfs_fs_ro ${CLI_NAME} ;
-		then
+		if enable_nfs_fs_ro ${CLI_NAME}; then
 			Log "$PROGRAM:$WORKFLOW:postbackup:NFS:ENABLE(ro):$CLI_NAME: ... Success!"
 		else
 			report_error "ERROR:$PROGRAM:$WORKFLOW:postbackup:NFS:ENABLE (ro):$CLI_NAME: Problem enabling NFS export (ro)! aborting ..."

--- a/usr/share/drlm/client/add/default/609_gen_srv_cfg_files_from_db.sh
+++ b/usr/share/drlm/client/add/default/609_gen_srv_cfg_files_from_db.sh
@@ -50,13 +50,7 @@ else
     chmod 755 $STORDIR/$CLI_NAME
 
     if add_nfs_export $CLI_NAME ; then
-
-        if enable_nfs_fs_rw $CLI_NAME ; then
-            Log "$PROGRAM:$WORKFLOW: NFS service reconfiguration complete!"
-        else
-            Error "$PROGRAM:$WORKFLOW: NFS service reconfiguration failed! See $LOGFILE for details."
-        fi
-
+        Log "$PROGRAM:$WORKFLOW: NFS service reconfiguration complete!"
     else
         Error "$PROGRAM:$WORKFLOW: NFS service reconfiguration failed! See $LOGFILE for details."
     fi

--- a/usr/share/drlm/client/add/default/609_gen_srv_cfg_files_from_db.sh
+++ b/usr/share/drlm/client/add/default/609_gen_srv_cfg_files_from_db.sh
@@ -28,27 +28,27 @@ else
 
     Log "$PROGRAM:$WORKFLOW: Populating $HOSTS_FILE configuration ..."
 
-    if $(hosts_add $CLI_NAME $CLI_IP) ; then
-	Log "$PROGRAM:$WORKFLOW: $CLI_NAME added to $HOSTS_FILE ..." 
+    if $(hosts_add $CLI_NAME $CLI_IP); then
+        Log "$PROGRAM:$WORKFLOW: $CLI_NAME added to $HOSTS_FILE ..." 
     else
-	Log "WARNING:$PROGRAM:$WORKFLOW: $CLI_NAME already exists in $HOSTS_FILE !"
+	    Log "WARNING:$PROGRAM:$WORKFLOW: $CLI_NAME already exists in $HOSTS_FILE !"
     fi
 
     Log "$PROGRAM:$WORKFLOW: Populating DHCP configuration ..."
 
     generate_dhcp
 
-    if reload_dhcp ; then
-	Log "$PROGRAM:$WORKFLOW: DHCP service reconfiguration complete!"
+    if reload_dhcp; then
+	    Log "$PROGRAM:$WORKFLOW: DHCP service reconfiguration complete!"
     else
-	Error "$PROGRAM:$WORKFLOW: DHCP service reconfiguration failed! See $LOGFILE for details."
+	    Error "$PROGRAM:$WORKFLOW: DHCP service reconfiguration failed! See $LOGFILE for details."
     fi
 
     Log "$PROGRAM:$WORKFLOW: Populating NFS configuration ..."
 
     mkdir -p $STORDIR/$CLI_NAME
     chmod 755 $STORDIR/$CLI_NAME
-
+    
     if add_nfs_export $CLI_NAME ; then
         Log "$PROGRAM:$WORKFLOW: NFS service reconfiguration complete!"
     else

--- a/usr/share/drlm/conf/default.conf
+++ b/usr/share/drlm/conf/default.conf
@@ -105,7 +105,6 @@ mkfs.ext2
 mkfs.ext4
 mktemp
 openssl
-wget
 ssh
 sqlite3
 cat

--- a/usr/share/drlm/lib/nfs-functions.sh
+++ b/usr/share/drlm/lib/nfs-functions.sh
@@ -29,7 +29,6 @@ function unconfigure_nfs_exports ()
     if [ -f ${EXPORT_CLI_NAME} ]; then
       mv ${EXPORT_CLI_NAME} ${EXPORT_CLI_NAME_DISABLED}
     fi
-    
   done
   
 #Removes the nfs configuration file from CLIDB active backups
@@ -104,7 +103,6 @@ function reload_nfs ()
 
 function add_nfs_export ()
 {
-
   local CLI_NAME=${1}
   local EXPORT_CLI_NAME=${NFS_DIR}/exports.d/${CLI_NAME}.drlm.exports
   if [ ! -f "${EXPORT_CLI_NAME}" ]; then

--- a/usr/share/drlm/lib/nfs-functions.sh
+++ b/usr/share/drlm/lib/nfs-functions.sh
@@ -2,28 +2,50 @@
 # $NFS_DIR is the default.conf variable of nfs dir file
 # $NFS_FILE is the default.conf variable of nfs configuration file
 
-function generate_nfs_exports () 
+function configure_nfs_exports () 
 {
-  cp $NFS_FILE $NFS_DIR/exports.bkp
-  cat /dev/null > $NFS_FILE
-
-  for CLIENT in $(get_all_clients) ; do
-    local CLI_ID=$(echo $CLIENT | awk -F":" '{print $1}')
-    local CLI_NAME=$(echo $CLIENT | awk -F":" '{print $2}')
-    local CLI_MAC=$(echo $CLIENT | awk -F":" '{print $3}')
-    local CLI_IP=$(echo $CLIENT | awk -F":" '{print $4}')
-    local CLI_OS=$(echo $CLIENT | awk -F":" '{print $5}')
-    local CLI_NET=$(echo $CLIENT | awk -F":" '{print $6}')
-    echo "$STORDIR/$CLI_NAME $CLI_NAME(rw,sync,no_root_squash,no_subtree_check)" | tee -a $NFS_FILE > /dev/null
+  for BACKUPLINE in $(get_active_backups) ; do
+    local DR_FILE=$(echo ${BACKUPLINE} | awk -F":" '{ print $3 }')
+    local CLI_NAME=$(echo ${DR_FILE}| cut -d"." -f1)
+    local NFS_OPTS=$( echo ${NFS_OPTS} | sed 's|rw,|ro,|' )
+    local EXPORT_CLI_NAME=${NFS_DIR}/exports.d/${CLI_NAME}.drlm.exports
+    local EXPORT_CLI_NAME_DISABLED=${NFS_DIR}/exports.d/.${CLI_NAME}.drlm.exports
+    if [ -f ${EXPORT_CLI_NAME_DISABLED} ]; then
+      mv ${EXPORT_CLI_NAME_DISABLED} ${EXPORT_CLI_NAME}
+    else
+      echo "${STORDIR}/${CLI_NAME} ${CLI_NAME}(${NFS_OPTS})" | tee ${EXPORT_CLI_NAME} > /dev/null
+    fi
   done
-#Generates the nfs configuration file from CLIDB
+#Generates the nfs configuration file from CLIDB active backups
+}
+
+function unconfigure_nfs_exports () 
+{
+  for BACKUPLINE in $(get_active_backups) ; do
+    local DR_FILE=$(echo ${BACKUPLINE} | awk -F":" '{ print $3 }')
+    local CLI_NAME=$(echo ${DR_FILE}| cut -d"." -f1)
+    local EXPORT_CLI_NAME=${NFS_DIR}/exports.d/${CLI_NAME}.drlm.exports
+    local EXPORT_CLI_NAME_DISABLED=${NFS_DIR}/exports.d/.${CLI_NAME}.drlm.exports
+    if [ -f ${EXPORT_CLI_NAME} ]; then
+      mv ${EXPORT_CLI_NAME} ${EXPORT_CLI_NAME_DISABLED}
+    fi
+    
+  done
+  
+#Removes the nfs configuration file from CLIDB active backups
 }
 
 function enable_nfs_fs_ro ()
 {
   local CLI_NAME=$1
-
-  exportfs -vo ro,sync,no_root_squash,no_subtree_check ${CLI_NAME}:${STORDIR}/${CLI_NAME}
+  local NFS_OPTS=$( echo ${NFS_OPTS} | sed 's|rw,|ro,|' )
+  local EXPORT_CLI_NAME=${NFS_DIR}/exports.d/${CLI_NAME}.drlm.exports
+  local EXPORT_CLI_NAME_DISABLED=${NFS_DIR}/exports.d/.${CLI_NAME}.drlm.exports
+  if [ -f ${EXPORT_CLI_NAME_DISABLED} ]; then
+    rm -f ${EXPORT_CLI_NAME_DISABLED}
+  fi
+  echo "${STORDIR}/${CLI_NAME} ${CLI_NAME}(${NFS_OPTS})" | tee ${EXPORT_CLI_NAME} > /dev/null
+  exportfs -r
   if [ $? -eq 0 ]; then sleep 1; return 0; else return 1; fi
   # Return 0 if OK or 1 if NOK
 }
@@ -31,8 +53,13 @@ function enable_nfs_fs_ro ()
 function enable_nfs_fs_rw ()
 {
   local CLI_NAME=$1
-
-  exportfs -vo rw,sync,no_root_squash,no_subtree_check ${CLI_NAME}:${STORDIR}/${CLI_NAME}
+  local EXPORT_CLI_NAME=${NFS_DIR}/exports.d/${CLI_NAME}.drlm.exports
+  local EXPORT_CLI_NAME_DISABLED=${NFS_DIR}/exports.d/.${CLI_NAME}.drlm.exports
+  if [ -f ${EXPORT_CLI_NAME_DISABLED} ]; then
+    rm ${EXPORT_CLI_NAME_DISABLED}
+  fi
+  echo "${STORDIR}/${CLI_NAME} ${CLI_NAME}(${NFS_OPTS})" | tee ${EXPORT_CLI_NAME} > /dev/null
+  exportfs -r
   if [ $? -eq 0 ]; then sleep 1; return 0; else return 1; fi
   # Return 0 if OK or 1 if NOK
 }
@@ -40,9 +67,11 @@ function enable_nfs_fs_rw ()
 function disable_nfs_fs ()
 {
   local CLI_NAME=$1
-  
-  if [[ $(exportfs | grep -w ${STORDIR}/${CLI_NAME}) ]]; then
-    exportfs -vu ${CLI_NAME}:${STORDIR}/${CLI_NAME}
+  local EXPORT_CLI_NAME=${NFS_DIR}/exports.d/${CLI_NAME}.drlm.exports
+  local EXPORT_CLI_NAME_DISABLED=${NFS_DIR}/exports.d/.${CLI_NAME}.drlm.exports
+  if [[ -f ${EXPORT_CLI_NAME} ]]; then
+    mv ${EXPORT_CLI_NAME} ${EXPORT_CLI_NAME_DISABLED}
+    exportfs -r
     if [ $? -eq 0 ]; then sleep 1; exportfs -f; return 0; else return 1; fi
     # Return 0 if OK or 1 if NOK
   else
@@ -52,52 +81,59 @@ function disable_nfs_fs ()
 
 function reload_nfs ()
 {
-	exportfs -a
-	if [ $? -ne 0 ]; then
-		mv $NFS_DIR/exports.bkp $NFS_FILE
-		exportfs -a
-		return 1
-	else
-		return 0
-	fi
+  exportfs -a
+  if [ $? -ne 0 ]; then
+    mv $NFS_DIR/exports.bkp $NFS_FILE
+    exportfs -a
+    return 1
+  else
+    return 0
+  fi
 }
 
 function add_nfs_export ()
 {
 
-	local CLI_NAME=$1
-	local EXIST=$(grep -w ${STORDIR} ${NFS_FILE} | grep -w ${CLI_NAME})
-	if [ -z "${EXIST}" ]; then
-		echo "$STORDIR/$CLI_NAME $CLI_NAME(rw,sync,no_root_squash,no_subtree_check)" | tee -a $NFS_FILE > /dev/null
-		if [ $? -eq 0 ]; then
-                    NFSCHECK=$(lsmod | grep nfs)
-                    if [[ -z "$NFSCHECK" ]]; then
-                        if [ $(ps -p 1 -o comm=) = "systemd" ]; then
-                            systemctl start $NFS_SVC_NAME.service > /dev/null
-                        else
-                            service $NFS_SVC_NAME start > /dev/null
-                        fi
-                    fi
-		    return 0
-		else
-		    return 1
-		fi
-	fi
+  local CLI_NAME=$1
+  local EXPORT_CLI_NAME=${NFS_DIR}/exports.d/${CLI_NAME}.drlm.exports
+  if [ ! -f "${EXPORT_CLI_NAME}" ]; then
+    echo "${STORDIR}/${CLI_NAME} ${CLI_NAME}(${NFS_OPTS})" | tee ${EXPORT_CLI_NAME} > /dev/null
+    if [ $? -eq 0 ]; then
+      NFSCHECK=$(lsmod | grep nfs)
+      if [[ -z "$NFSCHECK" ]]; then
+        if [ $(ps -p 1 -o comm=) = "systemd" ]; then
+          systemctl start $NFS_SVC_NAME.service > /dev/null
+        else
+          service $NFS_SVC_NAME start > /dev/null
+        fi
+      fi
+      return 0
+    else
+      return 1
+    fi
+  fi
 # Return 0 if OK or 1 if NOK
 }
 
 
 function del_nfs_export ()
 {
-	local CLI_NAME=$1
-	local EXIST=$(grep -w ${STORDIR} ${NFS_FILE} | grep -w ${CLI_NAME})
-	if [ -n "${EXIST}" ]; then
-		ex -s -c ":/${CLI_NAME} ${CLI_NAME}/d" -c ":wq" ${NFS_FILE}
-		if [ $? -eq 0 ]; then
-			return 0
-		else
-			return 1
-		fi
-	fi
+  local CLI_NAME=$1
+  local EXPORT_CLI_NAME=${NFS_DIR}/exports.d/${CLI_NAME}.drlm.exports
+  local EXPORT_CLI_NAME_DISABLED=${NFS_DIR}/exports.d/.${CLI_NAME}.drlm.exports
+  local rval='0'
+  if [ -f ${EXPORT_CLI_NAME} ]; then
+    rm -f ${EXPORT_CLI_NAME}
+    rval=$?
+  fi
+  if [ -f ${EXPORT_CLI_NAME_DISABLED} ]; then
+    rm -f ${EXPORT_CLI_NAME_DISABLED}
+    rval=$(( ${rval} + $?))
+  fi
+  if [ ${rval} -eq 0 ]; then
+    return 0
+  else
+    return 1
+  fi
 # Return 0 if OK or 1 if NOK
 }


### PR DESCRIPTION
also fixed some minor typo

#### Disaster Recovery Linux Manager (DRLM) Pull Request Template

Please fill in the following items before submitting a new Pull Request:

##### PR details:

* PR type : Enhancement 
* Reference to related issue (issue link): 
* Impact : Low
* Did you test this PR? yes
* Brief description of the changes in this PR:

Enhancement #138
New NFS configuration function leverage a strict file based approach
Every client has its own export file located under /etc/exports.d
Messing with /etc/exports is totally avoided
Current export state is always understandable by simply checking the files in /etc/exports.d
Filename follow this pattern ${CLI_NAME}.drlm.exports
Enabling an export is implemented by creating the file in /etc/exports.d
Disabling an export is implemented prepending a '.' to the file
drlm-stord now disables nfs exports at shutdown
drlm-stord enables nfs exports only for active backups at startup
