### PR TITLE
Reworked NFS Functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -209,7 +209,8 @@ $(name)-$(distversion).tar.gz:
 	@echo -e "\033[1m== Building archive $(name)-$(distversion) ==\033[0;0m"
 	git checkout $(git_branch)
 	git ls-tree -r --name-only --full-tree $(git_branch) | \
-		tar -czf $(name)-$(distversion).tar.gz --transform='s,^,$(name)-$(distversion)/,S' --files-from=-
+		tar -czf $(name)-$(distversion).tar.gz --transform='s,^,$(name)-$(distversion)/,S' \
+		--files-from=- ./usr/sbin/drlm-api ./usr/share/drlm/www/drlm-api/drlm-api.go
 
 rpm: dist
 	@echo -e "\033[1m== Building RPM package $(name)-$(distversion) ==\033[0;0m"	

--- a/packaging/debian/postinst
+++ b/packaging/debian/postinst
@@ -7,6 +7,8 @@ case "$1" in
         [ ! -d /etc/drlm/alerts ] && mkdir /etc/drlm/alerts
         [ ! -d /var/log/drlm/rear ] && mkdir /var/log/drlm/rear
         chmod 775 /var/log/drlm/rear
+        #Check if /etc/exports.d directory is present
+        [ ! -d /etc/exports.d ] && mkdir /etc/exports.d && chmod 755 /etc/exports.d
 
         #Check if drlm.key has been generated in older installations.
         if [ ! -f /etc/drlm/cert/drlm.key ]; then

--- a/packaging/rpm/drlm.spec
+++ b/packaging/rpm/drlm.spec
@@ -119,6 +119,8 @@ fi
 ### Create logs folder
 mkdir -p /var/log/drlm/rear
 chmod 775 /var/log/drlm/rear
+### Create nfs exports directory folder
+[ ! -d /etc/exports.d ] && mkdir -p /etc/exports.d && chmod 755 /etc/exports.d
 ### IF IS INSTALL
 if [ "$1" == "1" ]; then
 ### create keys

--- a/usr/sbin/drlm-stord
+++ b/usr/sbin/drlm-stord
@@ -35,6 +35,7 @@ source $SHARE_DIR/conf/default.conf
 [ -f /etc/drlm/local.conf ] && source /etc/drlm/local.conf
 source $SHARE_DIR/lib/dbdrv/$DB_BACKEND-driver.sh
 source $SHARE_DIR/lib/backup-functions.sh
+source $SHARE_DIR/lib/nfs-functions.sh
 RETVAL=0
 
 # Only root can start the service
@@ -89,6 +90,15 @@ do_umount_stord() {
 	if [ $? -eq 0 ]; then sleep 1; return 0; else return 1; fi
 }
 
+do_configure_nfs(){
+	configure_nfs_exports
+	reload_nfs
+}
+do_unconfigure_nfs(){
+	unconfigure_nfs_exports
+	reload_nfs
+}
+
 case "$OSTYPE" in
 	RedHat)
 		# Source function library.
@@ -112,12 +122,12 @@ case "$1" in
 	start)
 		if [ ! -d $VAR_DIR/run ]; then
 			mkdir $VAR_DIR/run
-		fi  
+		fi
 		drlm-api &
 		echo $! > $VAR_DIR/run/drlm-api.pid
 
 		case "$OSTYPE" in
-			SuSE)			
+			SuSE)
 				echo $"Starting $DESC: "
 				for line in $(get_active_backups)
 				do
@@ -133,6 +143,11 @@ case "$1" in
 					rval=$?
 					[ $rval -ne 0 ] && RETVAL=$rval
 				done
+				echo "Configuring NFS exports"
+				do_configure_nfs
+				rval=$?
+				[ $rval -ne 0 ] && RETVAL=$rval
+
 				[ $RETVAL -ne 0 ] && exit $RETVAL
 				;;
 
@@ -150,9 +165,13 @@ case "$1" in
 					rval=$?
 					[ $rval -ne 0 ] && RETVAL=$rval
 				done
+				action $"Configuring NFS exports" do_configure_nfs
+				rval=$?
+				[ $rval -ne 0 ] && RETVAL=$rval
+
 				[ $RETVAL -ne 0 ] && exit $RETVAL
 				;;
-				
+
 			Debian)
 				echo "[....] Starting $DESC:."
 				for line in $(get_active_backups)
@@ -171,6 +190,11 @@ case "$1" in
 					[ $rval -ne 0 ] && RETVAL=$rval
 					log_end_msg $rval
 				done
+				log_begin_msg "Configuring NFS exports"
+				do_configure_nfs
+				rval=$?
+				[ $rval -ne 0 ] && RETVAL=$rval
+				log_end_msg $rval
 				log_daemon_msg "Starting $DESC"
 				[ $RETVAL -ne 0 ] && {
 					log_end_msg $RETVAL
@@ -188,6 +212,10 @@ case "$1" in
 		case "$OSTYPE" in
 			SuSE)
 				echo $"Shutting down $DESC: "
+				echo "Unconfiguring NFS exports"
+				do_unconfigure_nfs
+				rval=$?
+				[ $rval -ne 0 ] && RETVAL=$rval
 				for lo_dev in $(mount -l |egrep "loop|.dr" | grep -w "ro" | awk '{print $1}')
 				do
 					if [ -z "${lo_dev##*.dr*}" ]; then
@@ -209,6 +237,9 @@ case "$1" in
 
 			RedHat)
 				echo $"Shutting down $DESC: "
+				action $"Unconfiguring NFS exports" do_unconfigure_nfs
+				rval=$?
+				[ $rval -ne 0 ] && RETVAL=$rval
 				for lo_dev in $(mount -l |egrep "loop|.dr"| grep -w "ro" | awk '{print $1}')
 				do
 					if [ -z "${lo_dev##*.dr*}" ]; then
@@ -228,6 +259,11 @@ case "$1" in
 
 			Debian)
 				echo "[....] Stopping $DESC:."
+				log_begin_msg "Unconfiguring NFS exports"
+				do_unconfigure_nfs
+				rval=$?
+				[ $rval -ne 0 ] && RETVAL=$rval
+				log_end_msg $rval
 				for lo_dev in $(mount -l |egrep "loop|.dr"| grep -w "ro" | awk '{print $1}')
 				do
 					if [ -z "${lo_dev##*.dr*}" ]; then

--- a/usr/share/drlm/backup/mgr/default/059_disable_client_backup.sh
+++ b/usr/share/drlm/backup/mgr/default/059_disable_client_backup.sh
@@ -1,46 +1,55 @@
 # bkpmgr workflow
+function wf_disable_client_backup(){
+   if [ ! -z ${1} ]; then
+      local A_BKP_ID_DB=${1}
+   fi
 
-if disable_nfs_fs ${CLI_NAME}; then
-   Log "$PROGRAM:$WORKFLOW:NFS:DISABLE:$CLI_NAME: .... Success!"
-else
-   Error "$PROGRAM:$WORKFLOW:NFS:DISABLE:$CLI_NAME: Problem disabling NFS export! aborting ..."
-fi
+   if disable_nfs_fs ${CLI_NAME} ; then
+      Log "$PROGRAM:$WORKFLOW:NFS:DISABLE:$CLI_NAME: .... Success!"
+   else
+      Error "$PROGRAM:$WORKFLOW:NFS:DISABLE:$CLI_NAME: Problem disabling NFS export! aborting ..."
+   fi
 
-if [ -n "$A_BKP_ID_DB" ]; then
-   Log "$PROGRAM:$WORKFLOW:${CLI_NAME}: Deactivating Backup ${A_BKP_ID_DB} for client: .... "
+   if [ -n "$A_BKP_ID_DB" ] ; then
+      Log "$PROGRAM:$WORKFLOW:${CLI_NAME}: Deactivating Backup ${A_BKP_ID_DB} for client: .... "
 
-   LO_MNT=$(mount -lt ext2,ext4 | grep -w "loop${CLI_ID}" | awk '{ print $3 }'| grep -w "${STORDIR}/${CLI_NAME}")
-   if [ -n "$LO_MNT" ]; then
-      if do_umount ${CLI_ID}; then
-         Log "$PROGRAM:$WORKFLOW:FS:UMOUNT:LOOPDEV(${CLI_ID}):MNT($STORDIR/$CLI_NAME): .... Success!"
-      else
-         Error "$PROGRAM:$WORKFLOW:FS:UMOUNT:LOOPDEV(${CLI_ID}):MNT($STORDIR/$CLI_NAME): Problem unmounting Filesystem! aborting ..."
+      LO_MNT=$(mount -lt ext2,ext4 | grep -w "loop${CLI_ID}" | awk '{ print $3 }'| grep -w "${STORDIR}/${CLI_NAME}")
+      if [ -n "$LO_MNT" ]; then
+         if do_umount ${CLI_ID} ; then
+            Log "$PROGRAM:$WORKFLOW:FS:UMOUNT:LOOPDEV(${CLI_ID}):MNT($STORDIR/$CLI_NAME): .... Success!"
+         else
+            Error "$PROGRAM:$WORKFLOW:FS:UMOUNT:LOOPDEV(${CLI_ID}):MNT($STORDIR/$CLI_NAME): Problem unmounting Filesystem! aborting ..."
+         fi
       fi
+
+      if disable_loop ${CLI_ID} ; then
+         Log "$PROGRAM:$WORKFLOW:LOOPDEV(${CLI_ID}):DISABLE:$CLI_NAME: .... Success!"
+      else
+         Error "$PROGRAM:$WORKFLOW:LOOPDEV(${CLI_ID}):DISABLE:$CLI_NAME: Problem disabling Loop Device! aborting ..."
+      fi
+
+      #Disable backup from database
+      if disable_backup_db ${A_BKP_ID_DB} ; then
+         Log "$PROGRAM:$WORKFLOW:MODE:perm:DB:disable:(ID: ${A_BKP_ID}):${CLI_NAME}: .... Success!"
+      else
+         Error "$PROGRAM:$WORKFLOW:MODE:perm:DB:disable:(ID: ${A_BKP_ID}):${CLI_NAME}: Problem disabling backup in database! aborting ..."
+      fi
+
+      Log "$PROGRAM:$WORKFLOW:${CLI_NAME}: Deactivating previous DR store for client: .... Success!"
    fi
+}
 
-   if disable_loop ${CLI_ID}; then
-      Log "$PROGRAM:$WORKFLOW:LOOPDEV(${CLI_ID}):DISABLE:$CLI_NAME: .... Success!"
-   else
-      Error "$PROGRAM:$WORKFLOW:LOOPDEV(${CLI_ID}):DISABLE:$CLI_NAME: Problem disabling Loop Device! aborting ..."
-   fi
-
-   #Disable backaup from database
-   if disable_backup_db ${A_BKP_ID_DB}; then
-      Log "$PROGRAM:$WORKFLOW:MODE:perm:DB:disable:(ID: ${A_BKP_ID}):${CLI_NAME}: .... Success!"
-   else
-      Error "$PROGRAM:$WORKFLOW:MODE:perm:DB:disable:(ID: ${A_BKP_ID}):${CLI_NAME}: Problem disabling backup in database! aborting ..."
-   fi
-
-   Log "$PROGRAM:$WORKFLOW:${CLI_NAME}: Deactivating previous DR store for client: .... Success!"
-fi
-
-if [ "$DISABLE" == "yes" ]; then
-   if enable_nfs_fs_rw ${CLI_NAME}; then
-      Log "$PROGRAM:$WORKFLOW:NFS:ENABLE (rw):$CLI_NAME: .... Success!"
-   else
-      Error "$PROGRAM:$WORKFLOW:NFS:ENABLE (rw):$CLI_NAME: Problem enabling NFS export (rw)! aborting ..."
-   fi
-
+if [[ ${DISABLE} == 'yes' ]]; then
+   wf_disable_client_backup
    Log "$PROGRAM:$WORKFLOW:${CLI_NAME}: Deactivating Backup ${A_BKP_ID_DB} for client: .... Success!"
    exit 0
+fi
+if [[ ${ENABLE} == 'yes' ]]; then
+   local A_BKP_ID_DB_OLD=$(get_active_cli_bkp_from_db_dbdrv ${CLI_NAME})
+   if wf_disable_client_backup ${A_BKP_ID_DB_OLD} ; then
+      Log "$PROGRAM:$WORKFLOW:${CLI_NAME}: Deactivating Backup ${A_BKP_ID_DB} for client: .... Success!"
+      return 0
+   else
+      return 1
+   fi
 fi

--- a/usr/share/drlm/backup/mgr/default/109_enable_client_backup.sh
+++ b/usr/share/drlm/backup/mgr/default/109_enable_client_backup.sh
@@ -1,31 +1,34 @@
 # bkpmgr workflow
+if [[ ${ENABLE} = 'yes' ]]; then
+    Log "$PROGRAM:$WORKFLOW:(ID: ${BKP_ID}):${CLI_NAME}: Enabling DRLM Store for client ...."
 
-Log "$PROGRAM:$WORKFLOW:(ID: ${BKP_ID}):${CLI_NAME}: Enabling DRLM Store for client ...."
+    DR_FILE=$(get_backup_drfile "$BKP_ID")
 
-DR_FILE=$(get_backup_drfile "$BKP_ID")
+    if [ -n "$DR_FILE" ]; then
 
-if [ -n "$DR_FILE" ]; then
-    if enable_loop_rw ${CLI_ID} ${DR_FILE} ; then
-        Log "$PROGRAM:$WORKFLOW:LOOPDEV(${CLI_ID}):ENABLE(ro):DR:${DR_FILE}: .... Success!"
-        if do_mount_ext4_ro ${CLI_ID} ${CLI_NAME} ; then
-         Log "$PROGRAM:$WORKFLOW:FS:MOUNT:LOOPDEV(${CLI_ID}):MNT($STORDIR/$CLI_NAME): .... Success!"
-            if enable_nfs_fs_ro ${CLI_NAME} ; then
-                Log "$PROGRAM:$WORKFLOW:NFS:ENABLE(ro):$CLI_NAME: .... Success!"
+        if enable_loop_rw ${CLI_ID} ${DR_FILE} ; then
+            Log "$PROGRAM:$WORKFLOW:LOOPDEV(${CLI_ID}):ENABLE(ro):DR:${DR_FILE}: .... Success!"
+            if do_mount_ext4_ro ${CLI_ID} ${CLI_NAME} ; then
+            Log "$PROGRAM:$WORKFLOW:FS:MOUNT:LOOPDEV(${CLI_ID}):MNT($STORDIR/$CLI_NAME): .... Success!"
+                if enable_nfs_fs_ro ${CLI_NAME} ; then
+                    Log "$PROGRAM:$WORKFLOW:NFS:ENABLE(ro):$CLI_NAME: .... Success!"
+                else
+                    Error "$PROGRAM:$WORKFLOW:NFS:ENABLE (ro):$CLI_NAME: Problem enabling NFS export (ro)! aborting ..."
+                fi
             else
-                Error "$PROGRAM:$WORKFLOW:NFS:ENABLE (ro):$CLI_NAME: Problem enabling NFS export (ro)! aborting ..."
+                Error "$PROGRAM:$WORKFLOW:FS:MOUNT:LOOPDEV(${CLI_ID}):MNT(${STORDIR}/${CLI_NAME}): Problem mounting Filesystem!"
             fi
         else
-            Error "$PROGRAM:$WORKFLOW:FS:MOUNT:LOOPDEV(${CLI_ID}):MNT(${STORDIR}/${CLI_NAME}): Problem mounting Filesystem!"
+            Error "$PROGRAM:$WORKFLOW:LOOPDEV(${CLI_ID}):ENABLE(ro):DR:${DR_FILE}: Problem enabling Loop Device (ro)!"
         fi
-    else
-        Error "$PROGRAM:$WORKFLOW:LOOPDEV(${CLI_ID}):ENABLE(ro):DR:${DR_FILE}: Problem enabling Loop Device (ro)!"
+
+        if enable_backup_db ${BKP_ID} ; then
+            Log "$PROGRAM:$WORKFLOW:MODE:perm:DB:enable:(ID: ${BKP_ID}):${CLI_NAME}: .... Success!"
+        else
+            Error "$PROGRAM:$WORKFLOW:MODE:perm:DB:enable:(ID: ${BKP_ID}):${CLI_NAME}: Problem enabling backup in database! aborting ..."
+        fi
     fi
 
-    if enable_backup_db ${BKP_ID} ; then
-        Log "$PROGRAM:$WORKFLOW:MODE:perm:DB:enable:(ID: ${BKP_ID}):${CLI_NAME}: .... Success!"
-    else
-        Error "$PROGRAM:$WORKFLOW:MODE:perm:DB:enable:(ID: ${BKP_ID}):${CLI_NAME}: Problem enabling backup in database! aborting ..."
-    fi
+    Log "$PROGRAM:$WORKFLOW:(ID: ${BKP_ID}):${CLI_NAME}: Enabling DRLM Store for client .... Success!"
+
 fi
-
-Log "$PROGRAM:$WORKFLOW:(ID: ${BKP_ID}):${CLI_NAME}: Enabling DRLM Store for client .... Success!"

--- a/usr/share/drlm/client/add/default/609_gen_srv_cfg_files_from_db.sh
+++ b/usr/share/drlm/client/add/default/609_gen_srv_cfg_files_from_db.sh
@@ -28,20 +28,20 @@ else
 
     Log "$PROGRAM:$WORKFLOW: Populating $HOSTS_FILE configuration ..."
 
-    if $(hosts_add $CLI_NAME $CLI_IP); then
-        Log "$PROGRAM:$WORKFLOW: $CLI_NAME added to $HOSTS_FILE ..." 
+    if $(hosts_add $CLI_NAME $CLI_IP) ; then
+	Log "$PROGRAM:$WORKFLOW: $CLI_NAME added to $HOSTS_FILE ..."
     else
-	    Log "WARNING:$PROGRAM:$WORKFLOW: $CLI_NAME already exists in $HOSTS_FILE !"
+	Log "WARNING:$PROGRAM:$WORKFLOW: $CLI_NAME already exists in $HOSTS_FILE !"
     fi
 
     Log "$PROGRAM:$WORKFLOW: Populating DHCP configuration ..."
 
     generate_dhcp
 
-    if reload_dhcp; then
-	    Log "$PROGRAM:$WORKFLOW: DHCP service reconfiguration complete!"
+    if reload_dhcp ; then
+	Log "$PROGRAM:$WORKFLOW: DHCP service reconfiguration complete!"
     else
-	    Error "$PROGRAM:$WORKFLOW: DHCP service reconfiguration failed! See $LOGFILE for details."
+	Error "$PROGRAM:$WORKFLOW: DHCP service reconfiguration failed! See $LOGFILE for details."
     fi
 
     Log "$PROGRAM:$WORKFLOW: Populating NFS configuration ..."
@@ -49,14 +49,8 @@ else
     mkdir -p $STORDIR/$CLI_NAME
     chmod 755 $STORDIR/$CLI_NAME
 
-    if add_nfs_export $CLI_NAME; then
-
-        if enable_nfs_fs_rw $CLI_NAME; then
-            Log "$PROGRAM:$WORKFLOW: NFS service reconfiguration complete!"
-        else
-            Error "$PROGRAM:$WORKFLOW: NFS service reconfiguration failed! See $LOGFILE for details."
-        fi
-
+    if add_nfs_export $CLI_NAME ; then
+        Log "$PROGRAM:$WORKFLOW: NFS service reconfiguration complete!"
     else
         Error "$PROGRAM:$WORKFLOW: NFS service reconfiguration failed! See $LOGFILE for details."
     fi
@@ -68,7 +62,7 @@ if config_client_cfg ${CLI_NAME} ${SRV_IP}; then
     LogPrint "$PROGRAM:$WORKFLOW: /etc/drlm/clients/${CLI_NAME}.cfg has been created with default configuration, check ReaR options to change it if needed"
 else
     Error "$PROGRAM:$WORKFLOW: Problem creating configuration file for ${CLI_NAME}"
-fi	
+fi
 
 Log "------------------------------------------------------------------"
 Log "$PROGRAM $WORWFLOW:                                               "

--- a/usr/share/drlm/lib/nfs-functions.sh
+++ b/usr/share/drlm/lib/nfs-functions.sh
@@ -1,49 +1,77 @@
 # file with default nfs functions to implement.
 # $NFS_DIR is the default.conf variable of nfs dir file
 # $NFS_FILE is the default.conf variable of nfs configuration file
+# $NFS_OPTS is the default.conf variable of nfs configuration file
 
-function generate_nfs_exports () 
+#Generates the nfs configuration file from CLIDB active backups
+function configure_nfs_exports ()
 {
-  cp $NFS_FILE $NFS_DIR/exports.bkp
-  cat /dev/null > $NFS_FILE
-
-  for CLIENT in $(get_all_clients) ; do
-    local CLI_ID=$(echo $CLIENT | awk -F":" '{print $1}')
-    local CLI_NAME=$(echo $CLIENT | awk -F":" '{print $2}')
-    local CLI_MAC=$(echo $CLIENT | awk -F":" '{print $3}')
-    local CLI_IP=$(echo $CLIENT | awk -F":" '{print $4}')
-    local CLI_OS=$(echo $CLIENT | awk -F":" '{print $5}')
-    local CLI_NET=$(echo $CLIENT | awk -F":" '{print $6}')
-    echo "$STORDIR/$CLI_NAME $CLI_NAME(${NFS_OPTS})" | tee -a $NFS_FILE > /dev/null
+  for BACKUPLINE in $(get_active_backups) ; do
+    local DR_FILE=$(echo ${BACKUPLINE} | awk -F":" '{ print $3 }')
+    local CLI_NAME=$(echo ${DR_FILE}| cut -d"." -f1)
+    local NFS_OPTS=$( echo ${NFS_OPTS} | sed 's|rw,|ro,|' )
+    local EXPORT_CLI_NAME=${NFS_DIR}/exports.d/${CLI_NAME}.drlm.exports
+    local EXPORT_CLI_NAME_DISABLED=${NFS_DIR}/exports.d/.${CLI_NAME}.drlm.exports
+    if [ -f ${EXPORT_CLI_NAME_DISABLED} ]; then
+      mv ${EXPORT_CLI_NAME_DISABLED} ${EXPORT_CLI_NAME}
+    else
+      echo "${STORDIR}/${CLI_NAME} ${CLI_NAME}(${NFS_OPTS})" | tee ${EXPORT_CLI_NAME} > /dev/null
+    fi
   done
-#Generates the nfs configuration file from CLIDB
+}
+
+#Removes the nfs configuration file from CLIDB active backups
+function unconfigure_nfs_exports ()
+{
+  for BACKUPLINE in $(get_active_backups) ; do
+    local DR_FILE=$(echo ${BACKUPLINE} | awk -F":" '{ print $3 }')
+    local CLI_NAME=$(echo ${DR_FILE}| cut -d"." -f1)
+    local EXPORT_CLI_NAME=${NFS_DIR}/exports.d/${CLI_NAME}.drlm.exports
+    local EXPORT_CLI_NAME_DISABLED=${NFS_DIR}/exports.d/.${CLI_NAME}.drlm.exports
+    if [ -f ${EXPORT_CLI_NAME} ]; then
+      mv ${EXPORT_CLI_NAME} ${EXPORT_CLI_NAME_DISABLED}
+    fi
+  done
 }
 
 function enable_nfs_fs_ro ()
 {
-  local CLI_NAME=$1
+  local CLI_NAME=${1}
   local NFS_OPTS=$( echo ${NFS_OPTS} | sed 's|rw,|ro,|' )
-  exportfs -vo ${NFS_OPTS} ${CLI_NAME}:${STORDIR}/${CLI_NAME}
-  if [ $? -eq 0 ]; then sleep 1; return 0; else return 1; fi
+  local EXPORT_CLI_NAME=${NFS_DIR}/exports.d/${CLI_NAME}.drlm.exports
+  local EXPORT_CLI_NAME_DISABLED=${NFS_DIR}/exports.d/.${CLI_NAME}.drlm.exports
+  if [ -f ${EXPORT_CLI_NAME_DISABLED} ]; then
+    rm -f ${EXPORT_CLI_NAME_DISABLED}
+  fi
+  echo "${STORDIR}/${CLI_NAME} ${CLI_NAME}(${NFS_OPTS})" | tee ${EXPORT_CLI_NAME} > /dev/null
+  reload_nfs ${EXPORT_CLI_NAME}
+  if [ ${?} -eq 0 ]; then sleep 1; return 0; else return 1; fi
   # Return 0 if OK or 1 if NOK
 }
 
 function enable_nfs_fs_rw ()
 {
-  local CLI_NAME=$1
-
-  exportfs -vo ${NFS_OPTS} ${CLI_NAME}:${STORDIR}/${CLI_NAME}
-  if [ $? -eq 0 ]; then sleep 1; return 0; else return 1; fi
+  local CLI_NAME=${1}
+  local EXPORT_CLI_NAME=${NFS_DIR}/exports.d/${CLI_NAME}.drlm.exports
+  local EXPORT_CLI_NAME_DISABLED=${NFS_DIR}/exports.d/.${CLI_NAME}.drlm.exports
+  if [ -f ${EXPORT_CLI_NAME_DISABLED} ]; then
+    rm ${EXPORT_CLI_NAME_DISABLED}
+  fi
+  echo "${STORDIR}/${CLI_NAME} ${CLI_NAME}(${NFS_OPTS})" | tee ${EXPORT_CLI_NAME} > /dev/null
+  reload_nfs ${EXPORT_CLI_NAME}
+  if [ ${?} -eq 0 ]; then sleep 1; return 0; else return 1; fi
   # Return 0 if OK or 1 if NOK
 }
 
 function disable_nfs_fs ()
 {
-  local CLI_NAME=$1
-  
-  if [[ $(exportfs | grep -w ${STORDIR}/${CLI_NAME}) ]]; then
-    exportfs -vu ${CLI_NAME}:${STORDIR}/${CLI_NAME}
-    if [ $? -eq 0 ]; then sleep 1; exportfs -f; return 0; else return 1; fi
+  local CLI_NAME=${1}
+  local EXPORT_CLI_NAME=${NFS_DIR}/exports.d/${CLI_NAME}.drlm.exports
+  local EXPORT_CLI_NAME_DISABLED=${NFS_DIR}/exports.d/.${CLI_NAME}.drlm.exports
+  if [[ -f ${EXPORT_CLI_NAME} ]]; then
+    mv ${EXPORT_CLI_NAME} ${EXPORT_CLI_NAME_DISABLED}
+    reload_nfs
+    if [ ${?} -eq 0 ]; then sleep 1; exportfs -f; return 0; else return 1; fi
     # Return 0 if OK or 1 if NOK
   else
     return 0
@@ -52,52 +80,69 @@ function disable_nfs_fs ()
 
 function reload_nfs ()
 {
-	exportfs -a
-	if [ $? -ne 0 ]; then
-		mv $NFS_DIR/exports.bkp $NFS_FILE
-		exportfs -a
-		return 1
-	else
-		return 0
-	fi
+  if [ -z ${@} ]; then
+    exportfs -r
+    if [ ${?} -ne 0 ]; then
+      return 1
+    else
+      return 0
+    fi
+  else
+    local NEW_NFS_EXPORT=${1}
+    exportfs -r
+    if [ ${?} -ne 0 ]; then
+      mv ${NEW_NFS_EXPORT}{,.err}
+      echo "Check ${1}.err for errors"
+      exportfs -r
+      return 1
+    else
+      return 0
+    fi
+  fi
 }
 
 function add_nfs_export ()
 {
-
-	local CLI_NAME=$1
-	local EXIST=$(grep -w ${STORDIR} ${NFS_FILE} | grep -w ${CLI_NAME})
-	if [ -z "${EXIST}" ]; then
-		echo "$STORDIR/$CLI_NAME $CLI_NAME(${NFS_OPTS})" | tee -a $NFS_FILE > /dev/null
-		if [ $? -eq 0 ]; then
-                    NFSCHECK=$(lsmod | grep nfs)
-                    if [[ -z "$NFSCHECK" ]]; then
-                        if [ $(ps -p 1 -o comm=) = "systemd" ]; then
-                            systemctl start $NFS_SVC_NAME.service > /dev/null
-                        else
-                            service $NFS_SVC_NAME start > /dev/null
-                        fi
-                    fi
-		    return 0
-		else
-		    return 1
-		fi
-	fi
+  local CLI_NAME=${1}
+  local EXPORT_CLI_NAME=${NFS_DIR}/exports.d/${CLI_NAME}.drlm.exports
+  if [ ! -f "${EXPORT_CLI_NAME}" ]; then
+    echo "${STORDIR}/${CLI_NAME} ${CLI_NAME}(${NFS_OPTS})" | tee ${EXPORT_CLI_NAME} > /dev/null
+    if [ $? -eq 0 ]; then
+      NFSCHECK=$(lsmod | grep nfs)
+      if [[ -z "${NFSCHECK}" ]]; then
+        if [ $(ps -p 1 -o comm=) = "systemd" ]; then
+          systemctl start ${NFS_SVC_NAME}.service > /dev/null
+        else
+          service ${NFS_SVC_NAME} start > /dev/null
+        fi
+      fi
+      reload_nfs ${EXPORT_CLI_NAME}
+      return ${?}
+    else
+      return 1
+    fi
+  fi
 # Return 0 if OK or 1 if NOK
 }
 
-
 function del_nfs_export ()
 {
-	local CLI_NAME=$1
-	local EXIST=$(grep -w ${STORDIR} ${NFS_FILE} | grep -w ${CLI_NAME})
-	if [ -n "${EXIST}" ]; then
-		ex -s -c ":/${CLI_NAME} ${CLI_NAME}/d" -c ":wq" ${NFS_FILE}
-		if [ $? -eq 0 ]; then
-			return 0
-		else
-			return 1
-		fi
-	fi
+  local CLI_NAME=${1}
+  local EXPORT_CLI_NAME=${NFS_DIR}/exports.d/${CLI_NAME}.drlm.exports
+  local EXPORT_CLI_NAME_DISABLED=${NFS_DIR}/exports.d/.${CLI_NAME}.drlm.exports
+  local rval='0'
+  if [ -f ${EXPORT_CLI_NAME} ]; then
+    rm -f ${EXPORT_CLI_NAME}
+    rval=$?
+  fi
+  if [ -f ${EXPORT_CLI_NAME_DISABLED} ]; then
+    rm -f ${EXPORT_CLI_NAME_DISABLED}
+    rval=$(( ${rval} + ${?}))
+  fi
+  if [ ${rval} -eq 0 ]; then
+    return 0
+  else
+    return 1
+  fi
 # Return 0 if OK or 1 if NOK
 }


### PR DESCRIPTION
#### Disaster Recovery Linux Manager (DRLM) Pull Request Template

Please fill in the following items before submitting a new Pull Request:

##### PR details:

* PR type: New Feature / Hotfix
* Reference to related issue (issue link): #138 
* Impact: Low
* Did you test this PR? : Yes
* Brief description of the changes in this PR:

Enhancement to issue #138
New NFS configuration function leverage a strict file based approach
Every client has its own export file located under /etc/exports.d
Messing with /etc/exports is totally avoided
Current export state is always understandable by simply checking the files in /etc/exports.d
Filename follow this pattern ${CLI_NAME}.drlm.exports
Enabling an export is implemented by creating the file in /etc/exports.d
Disabling an export is implemented prepending a '.' to the file
drlm-stord now disables nfs exports at shutdown
drlm-stord enables nfs exports only for active backups at startup