### PR TITLE
Red Hat 8/Centos 8 compatible

### DIFF
--- a/usr/share/drlm/client/inst/default/359_install_client_soft.sh
+++ b/usr/share/drlm/client/inst/default/359_install_client_soft.sh
@@ -147,7 +147,7 @@ if [ -z "$CONFIG_ONLY" ]; then
             # if parameter -r/--repo in installclient try to install from oficial repositories
             if [ "$REPO_INST" = "true" ]; then
                 case "$VERSION" in
-                    [5*-7*])
+                    [5*-8*])
                         if install_rear_yum_repo "$USER" "$CLI_NAME" "$SUDO"; then 
                             Log "ReaR has been installed from repo"
                         else 

--- a/usr/share/drlm/client/inst/default/459_start_services.sh
+++ b/usr/share/drlm/client/inst/default/459_start_services.sh
@@ -35,7 +35,7 @@ case "$DISTRO" in
 
     CentOS|RedHat)
         case "$VERSION" in
-            [5*-7*])
+            [5*-8*])
                 if ssh_start_services "$USER" "$CLI_NAME" "$(eval echo \$REAR_SERVICES_REDHAT"$VERSION")" "$DISTRO" "$SUDO"; then 
                     LogPrint "Services have been started succesfully" 
                 else 

--- a/usr/share/drlm/conf/default.conf
+++ b/usr/share/drlm/conf/default.conf
@@ -354,6 +354,7 @@ REAR_DEP_UBUNTU18="binutils attr nfs-common"
 REAR_DEP_REDHAT5="mkisofs mingetty syslinux nfs-utils portmap wget curl parted"
 REAR_DEP_REDHAT6="genisoimage mtools syslinux syslinux-nonlinux nfs-utils rpcbind wget parted bc"
 REAR_DEP_REDHAT7="attr genisoimage libusal mtools syslinux nfs-utils wget bc net-tools"
+REAR_DEP_REDHAT8="attr genisoimage libusal mtools syslinux nfs-utils wget bc net-tools"
 
 # SUSE Dependencies
 REAR_DEP_SUSE12=""
@@ -380,6 +381,7 @@ REAR_SERVICES_UBUNTU18="rpcbind"
 REAR_SERVICES_REDHAT5="portmap nfs"
 REAR_SERVICES_REDHAT6="rpcbind nfs"
 REAR_SERVIVES_REDHAT7="rpcbind"
+REAR_SERVIVES_REDHAT8="rpcbind"
 
 # SUSE Services
 REAR_SERVICES_SUSE11="rpcbind nfs"


### PR DESCRIPTION
#### Disaster Recovery Linux Manager (DRLM) Pull Request Template

added compatibility with Centos 8/Red Hat 8

##### PR details:

* PR type:Enhancement
* Reference to related issue (issue link): 
* Impact: Urgent
* Did you test this PR? yes
* Brief description of the changes in this PR: 
- Added required packages for Centos 8
- Added required services for Centos 8
-  install client and start services addapted for Centos 8/Red Hat 8


