### PR TITLE
Bash completion discriminate between enabled and disabled

### DIFF
--- a/etc/bash_completion.d/drlm_completions
+++ b/etc/bash_completion.d/drlm_completions
@@ -375,20 +375,40 @@ __drlm_delbackup ()
 			done
 			;;
 		-I | --id)
-			local i=0
-			prev3="${COMP_WORDS[COMP_CWORD-3]}"
-			if [ "$prev3" == "-c" ]; then
-				local client="${COMP_WORDS[COMP_CWORD-2]}"
-				query=$(get_all_backup_id_by_client_dbdrv "$client" "$cur")
-				for result in $query; do
-					COMPREPLY[i++]="$result"
-				done
-			else
-				query=$(get_all_backup_id_dbdrv "$cur")
-				for result in $query; do
-					COMPREPLY[i++]="$result"
-				done
-			fi
+
+      if __drlm_exist_option "-c --client" "$workflow"; then
+        # if exists -c Get client name
+        local i=0
+        client=""
+        while [ "$client" == "" ]; do
+          if [ "${COMP_WORDS[i]}" == "-c" ]; then
+            ((i++))
+            client="${COMP_WORDS[i]}"
+          else
+            ((i++))
+          fi
+        done
+
+        query=$(get_all_backup_id_by_client_dbdrv "$client" "$cur")
+        local i=0
+        for result in $query; do
+          COMPREPLY[i++]="$result"
+        done
+        query=$(get_all_snap_id_by_client_dbdrv "$client" "$cur")
+        for result in $query; do
+          COMPREPLY[i++]="$result"
+        done
+      else
+        query=$(get_all_backup_id_dbdrv "$cur")
+        local i=0
+        for result in $query; do
+          COMPREPLY[i++]="$result"
+        done
+        query=$(get_all_snap_id_dbdrv "$cur")
+        for result in $query; do
+          COMPREPLY[i++]="$result"
+        done
+      fi
 			;;
 		*)
 			__drlmcomp3 "$options_s" "$options_l"
@@ -754,21 +774,87 @@ __drlm_bkpmgr ()
 			done
 			;;
 		-I | --id)
-			local i=0
-			prev3="${COMP_WORDS[COMP_CWORD-3]}"
-			if [ "$prev3" == "-c" ]; then
-				local client="${COMP_WORDS[COMP_CWORD-2]}"
-				query=$(get_all_backup_id_by_client_dbdrv "$client" "$cur")
-				for result in $query; do
-					COMPREPLY[i++]="$result"
-				done
-			else
-				query=$(get_all_backup_id_dbdrv "$cur")
-				for result in $query; do
-					COMPREPLY[i++]="$result"
-				done
-			fi
-			;;
+      if __drlm_exist_option "-c --client" "$workflow"; then
+        # if exists -c Get client name
+        local i=0
+        client=""
+        while [ "$client" == "" ]; do
+          if [ "${COMP_WORDS[i]}" == "-c" ]; then
+            ((i++))
+            client="${COMP_WORDS[i]}"
+          else
+            ((i++))
+          fi
+        done
+
+        # check if $client exists
+        if exist_client_name_dbdrv "$client"; then
+          if __drlm_exist_option "-e --enable" "$workflow"; then
+            query=$(get_all_backup_disabled_id_by_client_dbdrv "$client" "$cur")
+            local i=0
+            for result in $query; do
+              COMPREPLY[i++]="$result"
+            done
+            query=$(get_all_snap_disabled_id_by_client_dbdrv "$client" "$cur")
+            for result in $query; do
+              COMPREPLY[i++]="$result"
+            done
+          elif __drlm_exist_option "-d --disable" "$workflow"; then
+            query=$(get_all_backup_enabled_id_by_client_dbdrv "$client" "$cur")
+            local i=0
+            for result in $query; do
+              COMPREPLY[i++]="$result"
+            done
+            query=$(get_all_snap_enabled_id_by_client_dbdrv "$client" "$cur")
+            for result in $query; do
+              COMPREPLY[i++]="$result"
+            done
+          else
+            query=$(get_all_backup_id_by_client_dbdrv "$client" "$cur")
+            local i=0
+            for result in $query; do
+              COMPREPLY[i++]="$result"
+            done
+            query=$(get_all_snap_id_by_client_dbdrv "$client" "$cur")
+            for result in $query; do
+              COMPREPLY[i++]="$result"
+            done
+          fi         
+        fi
+      else
+        if __drlm_exist_option "-e --enable" "$workflow"; then
+          query=$(get_all_backup_disabled_id_dbdrv "$cur")
+          local i=0
+          for result in $query; do
+            COMPREPLY[i++]="$result"
+          done
+          query=$(get_all_snap_disabled_id_dbdrv "$cur")
+          for result in $query; do
+            COMPREPLY[i++]="$result"
+          done
+        elif __drlm_exist_option "-d --disable" "$workflow"; then
+          query=$(get_all_backup_enabled_id_dbdrv "$cur")
+          local i=0
+          for result in $query; do
+            COMPREPLY[i++]="$result"
+          done
+          query=$(get_all_snap_enabled_id_dbdrv "$cur")
+          for result in $query; do
+            COMPREPLY[i++]="$result"
+          done
+        else
+          query=$(get_all_backup_id_dbdrv "$cur")
+          local i=0
+          for result in $query; do
+            COMPREPLY[i++]="$result"
+          done
+          query=$(get_all_snap_id_dbdrv "$cur")
+          for result in $query; do
+            COMPREPLY[i++]="$result"
+          done
+        fi
+      fi
+      ;;
 		*)
 			__drlmcomp3 "$options_s" "$options_l"
 			;;
@@ -853,11 +939,26 @@ __drlm_modnetwork ()
 			done
 			;;
 		-I | --id)
-			local i=0
-			query=$(get_all_network_id_dbdrv "$cur")
-			for result in $query; do
-				COMPREPLY[i++]="$result"
-			done
+      if __drlm_exist_option "-e --enable" "$workflow"; then
+        query=$(get_all_network_disabled_id_dbdrv "$cur")
+        local i=0
+        for result in $query; do
+          COMPREPLY[i++]="$result"
+        done
+      elif __drlm_exist_option "-d --disable" "$workflow"; then
+        query=$(get_all_network_enabled_id_dbdrv "$cur")
+        local i=0
+        for result in $query; do
+          COMPREPLY[i++]="$result"
+        done
+      else
+        query=$(get_all_network_id_dbdrv "$cur")
+        local i=0
+        for result in $query; do
+          COMPREPLY[i++]="$result"
+        done
+      fi
+
 			;;
     -e | -d | --enable | --disable)
       __drlmcomp3 "$options_s" "$options_l"

--- a/usr/share/drlm/lib/dbdrv/sqlite3-driver.sh
+++ b/usr/share/drlm/lib/dbdrv/sqlite3-driver.sh
@@ -405,6 +405,18 @@ function get_all_network_id_dbdrv ()
   echo $(echo "select idnetwork from networks where idnetwork like '${COMP}%';" | sqlite3 -init <(echo .timeout $SQLITE_TIMEOUT) $DB_PATH)
 }
 
+function get_all_network_enabled_id_dbdrv ()
+{
+  local COMP=$1
+  echo $(echo "select idnetwork from networks where active='1' and idnetwork like '${COMP}%';" | sqlite3 -init <(echo .timeout $SQLITE_TIMEOUT) $DB_PATH)
+}
+
+function get_all_network_disabled_id_dbdrv ()
+{
+  local COMP=$1
+  echo $(echo "select idnetwork from networks where active='0' and idnetwork like '${COMP}%';" | sqlite3 -init <(echo .timeout $SQLITE_TIMEOUT) $DB_PATH)
+}
+
 function mod_network_name_dbdrv ()
 {
   local NET_ID=$1
@@ -693,6 +705,41 @@ function get_all_backup_id_by_client_dbdrv () {
   echo $ID_LIST
 }
 
+function get_all_backup_enabled_id_by_client_dbdrv () {
+  local CLI_NAME=$1
+  local COMP=$2
+  local ID_LIST=$(echo "select idbackup from backups where active='1' and drfile like '${CLI_NAME}.%' and idbackup like '${COMP}%';" | sqlite3 -init <(echo .timeout $SQLITE_TIMEOUT) $DB_PATH)
+  echo $ID_LIST
+}
+
+function get_all_backup_disabled_id_by_client_dbdrv () {
+  local CLI_NAME=$1
+  local COMP=$2
+  local ID_LIST=$(echo "select idbackup from backups where active='0' and drfile like '${CLI_NAME}.%' and idbackup like '${COMP}%';" | sqlite3 -init <(echo .timeout $SQLITE_TIMEOUT) $DB_PATH)
+  echo $ID_LIST
+}
+
+function get_all_snap_id_by_client_dbdrv () {
+  local CLI_NAME=$1
+  local COMP=$2
+  local ID_LIST=$(echo "select idsnap from snaps, backups where backups.idbackup = snaps.idbackup and backups.drfile like '${CLI_NAME}.%' and snaps.idsnap like '${COMP}%';" | sqlite3 -init <(echo .timeout $SQLITE_TIMEOUT) $DB_PATH)
+  echo $ID_LIST
+}
+
+function get_all_snap_enabled_id_by_client_dbdrv () {
+  local CLI_NAME=$1
+  local COMP=$2
+  local ID_LIST=$(echo "select idsnap from snaps, backups where backups.idbackup = snaps.idbackup and snaps.active='1' and backups.drfile like '${CLI_NAME}.%' and snaps.idsnap like '${COMP}%';" | sqlite3 -init <(echo .timeout $SQLITE_TIMEOUT) $DB_PATH)
+  echo $ID_LIST
+}
+
+function get_all_snap_disabled_id_by_client_dbdrv () {
+  local CLI_NAME=$1
+  local COMP=$2
+  local ID_LIST=$(echo "select idsnap from snaps, backups where backups.idbackup = snaps.idbackup and snaps.active='0' and backups.drfile like '${CLI_NAME}.%' and snaps.idsnap like '${COMP}%';" | sqlite3 -init <(echo .timeout $SQLITE_TIMEOUT) $DB_PATH)
+  echo $ID_LIST
+}
+
 # function get_all_snap_id_by_backup_id_dbdrv () {
 #   local BKP_ID=$1
 #   local ID_LIST=$(echo "select idsnap from snaps where idbackup='${BKP_ID}';" | sqlite3 -init <(echo .timeout $SQLITE_TIMEOUT) $DB_PATH)
@@ -702,6 +749,36 @@ function get_all_backup_id_by_client_dbdrv () {
 function get_all_backup_id_dbdrv () {
   local COMP=$1
   local ID_LIST=$(echo "select idbackup from backups where idbackup like '${COMP}%';" | sqlite3 -init <(echo .timeout $SQLITE_TIMEOUT) $DB_PATH)
+  echo $ID_LIST
+}
+
+function get_all_backup_enabled_id_dbdrv () {
+  local COMP=$1
+  local ID_LIST=$(echo "select idbackup from backups where active='1' and idbackup like '${COMP}%';" | sqlite3 -init <(echo .timeout $SQLITE_TIMEOUT) $DB_PATH)
+  echo $ID_LIST
+}
+
+function get_all_backup_disabled_id_dbdrv () {
+  local COMP=$1
+  local ID_LIST=$(echo "select idbackup from backups where active='0' and idbackup like '${COMP}%';" | sqlite3 -init <(echo .timeout $SQLITE_TIMEOUT) $DB_PATH)
+  echo $ID_LIST
+}
+
+function get_all_snap_id_dbdrv () {
+  local COMP=$1
+  local ID_LIST=$(echo "select idsnap from snaps where idsnap like '${COMP}%';" | sqlite3 -init <(echo .timeout $SQLITE_TIMEOUT) $DB_PATH)
+  echo $ID_LIST
+}
+
+function get_all_snap_enabled_id_dbdrv () {
+  local COMP=$1
+  local ID_LIST=$(echo "select idsnap from snaps where active='1' and idsnap like '${COMP}%';" | sqlite3 -init <(echo .timeout $SQLITE_TIMEOUT) $DB_PATH)
+  echo $ID_LIST
+}
+
+function get_all_snap_disabled_id_dbdrv () {
+  local COMP=$1
+  local ID_LIST=$(echo "select idsnap from snaps where active='0' and idsnap like '${COMP}%';" | sqlite3 -init <(echo .timeout $SQLITE_TIMEOUT) $DB_PATH)
   echo $ID_LIST
 }
 


### PR DESCRIPTION
#### Disaster Recovery Linux Manager (DRLM) Pull Request Template

Please fill in the following items before submitting a new Pull Request:

##### PR details:

* PR type: Enhancement
* Impact: Low
* Did you test this PR? Tests done in Debian 10
* Brief description of the changes in this PR:

Now bash-completions only shows disabled backup/snaps when we are trying to enable or enabled backups/snaps when we are trying to disable.

