### PR TITLE
Solved import backup always skipping to import client config

### DIFF
--- a/usr/share/drlm/backup/imp/default/049_get_import_backup_configuration.sh
+++ b/usr/share/drlm/backup/imp/default/049_get_import_backup_configuration.sh
@@ -119,11 +119,11 @@ fi
 
 # At this point is available the content of the DR file
 # If exists *.*.drlm.cfg file in the mountpoint it means that is a backup done with a DRLM 2.4.0 or superior
-if [ -f "$TMP_MOUNTPOINT/*.*.drlm.cfg" ]; then
+IMP_CFG_FILE="$(ls $TMP_MOUNTPOINT/*.*.drlm.cfg)"
+if [ -f "$IMP_CFG_FILE" ]; then
 
-  IMP_CFG_FILE="$(ls $TMP_MOUNTPOINT/*.*.drlm.cfg)"
-  IMP_CLI_NAME="$(basename $(ls $TMP_MOUNTPOINT/*.*.drlm.cfg) | awk -F'.' {'print $1'})"
-  IMP_CLI_CFG="$(basename $(ls $TMP_MOUNTPOINT/*.*.drlm.cfg) | awk -F'.' {'print $2'})"
+  IMP_CLI_NAME="$(basename "$IMP_CFG_FILE" | awk -F'.' {'print $1'})"
+  IMP_CLI_CFG="$(basename "$IMP_CFG_FILE" | awk -F'.' {'print $2'})"
 
   IMPORT_CONFIGURATION_CONTENT="$(cat $IMP_CFG_FILE)"
 


### PR DESCRIPTION
#### Disaster Recovery Linux Manager (DRLM) Pull Request Template

Please fill in the following items before submitting a new Pull Request:

##### PR details:

* PR type (**Bug Fixing** / **New Feature** / **Enhancement** / **Other?**): Bug
* Impact (**Low** / **High** / **Critical** / **Urgent**): low
* Did you test this PR? yes
* Brief description of the changes in this PR: solve problem in condition for entering in the import config section

