### PR TITLE
Solve issue at runbackup umounting previous backups

### DIFF
--- a/usr/share/drlm/lib/backup-functions.sh
+++ b/usr/share/drlm/lib/backup-functions.sh
@@ -410,7 +410,7 @@ function do_umount ()
 {
   local DEVICE=$1
 
-  /bin/umount $DEVICE >> /dev/null 2>&1
+  /bin/umount -f $DEVICE >> /dev/null 2>&1
   if [ $? -eq 0 ]; then sleep 1; return 0; else return 1; fi
   # Return 0 if OK or 1 if NOK
 }


### PR DESCRIPTION
#### Disaster Recovery Linux Manager (DRLM) Pull Request Template

Please fill in the following items before submitting a new Pull Request:

##### PR details:

* PR type (**Bug Fixing** / **New Feature** / **Enhancement** / **Other?**): Enhancement
* Reference to related issue (issue link): 
* Impact (**Low** / **High** / **Critical** / **Urgent**): low
* Did you test this PR? yes
* Brief description of the changes in this PR: force umount at runbackup time when disabling previous backups

