### PR TITLE
avoid hidden rsync errors

### DIFF
--- a/doc/drlm-release-notes.rst
+++ b/doc/drlm-release-notes.rst
@@ -76,6 +76,10 @@ DRLM Version 2.4.10 (February 2023) - Release Notes
 
   * Bugfix in impbackup client configuration
 
+  * Bugfix runbackup umounting previous backups 
+
+  * Bugfix runbackup rsync hidden warning errors
+
 
 DRLM Version 2.4.9 (December 2022) - Release Notes
 --------------------------------------------------

--- a/packaging/debian/changelog
+++ b/packaging/debian/changelog
@@ -4,6 +4,8 @@ drlm (2.4.10) stable release; urgency=high
   * Bugfix in user deletion to skip error code 12
   * NEW! XML/JSON error reporting supported
   * Bugfix in impbackup client configuration
+  * Bugfix runbackup umounting previous backups 
+  * Bugfix runbackup rsync hidden warning errors
 
  -- Pau Roura <pau@brainupdaters.net>  Fri, 10 Feb 2023 00:00:00 +0100
 

--- a/packaging/rpm/drlm.spec
+++ b/packaging/rpm/drlm.spec
@@ -323,7 +323,10 @@ systemctl start drlm-tftpd.service
 - Bugfix in installclient tunnig_rear function
 - Bugfix avoid duplicate settings in /etc/drlm/local.conf during update or install process
 - Bugfix in user deletion to skip error code 12
+- NEW! XML/JSON error reporting supported
 - Bugfix in impbackup client configuration
+- Bugfix runbackup umounting previous backups 
+- Bugfix runbackup rsync hidden warning errors
 
 * Thu Nov 24 2022 Pau Roura <pau@brainupdaters.net> 2.4.9
 - Bugfix in importbackup Debian nbd detach

--- a/usr/share/drlm/conf/samples/client_default.cfg
+++ b/usr/share/drlm/conf/samples/client_default.cfg
@@ -21,8 +21,8 @@
 # Backup type ISO generates a rescue image in ISO format and backup data is stored
 # in a DRLM server directory.
 #
-# DRLM_BKP_TYPE=ISO (Default)
-#  |-- DRLM_BKP_PROT=RSYNC (Default)
+# DRLM_BKP_TYPE=ISO #(Default)
+#  |-- DRLM_BKP_PROT=RSYNC #(Default)
 #  |-- DRLM_BKP_PROT=NETFS
 #       |-- DRLM_BKP_PROG=TAR
 #       |-- DRLM_BKP_PROG=RSYNC
@@ -51,7 +51,7 @@
 # may be useful to use it by enabling incremental backups, DRLM_INCREMENTAL, also described below.
 #
 # DRLM_BKP_TYPE=DATA
-#  |-- DRLM_BKP_PROT=RSYNC (Default)
+#  |-- DRLM_BKP_PROT=RSYNC #(Default)
 #  |-- DRLM_BKP_PROT=NETFS
 #      |-- DRLM_BKP_PROG=TAR
 #      |-- DRLM_BKP_PROG=RSYNC

--- a/usr/share/drlm/lib/install-functions.sh
+++ b/usr/share/drlm/lib/install-functions.sh
@@ -546,6 +546,14 @@ function tunning_rear () {
     fi
   fi
 
+  # If rsync reports an error, abort backup process. Only afects rear < 2.7
+  if [ -f "/usr/share/rear/backup/RSYNC/default/50_make_rsync_backup.sh" ]; then
+      sed -i 's/test \"\$_rc\" -gt 0 \&\& VERBOSE\=1 LogPrint \"WARNING !/test \"\$_rc\" -gt 0 \&\& Error \"/g' /usr/share/rear/backup/RSYNC/default/50_make_rsync_backup.sh
+  fi
+  if [ -f "/usr/share/rear/backup/RSYNC/default/500_make_rsync_backup.sh" ]; then
+      sed -i 's/test \"\$_rc\" -gt 0 \&\& VERBOSE\=1 LogPrint \"WARNING !/test \"\$_rc\" -gt 0 \&\& Error \"/g' /usr/share/rear/backup/RSYNC/default/500_make_rsync_backup.sh
+  fi
+
   # remove rear cron file
   if $SUDO test -f "/etc/cron.d/rear"; then
     $SUDO rm -rf /etc/cron.d/rear


### PR DESCRIPTION
#### Disaster Recovery Linux Manager (DRLM) Pull Request Template

Please fill in the following items before submitting a new Pull Request:

##### PR details:

* PR type: **Bug Fixing**
* Impact: **Critical**
* Did you test this PR? Minimal test done in Debian 11
* Brief description of the changes in this PR:

If rsync reports an error, abort backup process for rear <2.7 versions
 
