### PR TITLE
Added ISO prefix to match PXE output dest type

### DIFF
--- a/packaging/debian/preinst
+++ b/packaging/debian/preinst
@@ -30,18 +30,18 @@ case "$1" in
 
     # Check if older versions than 2.4.12
     [ -f /usr/sbin/drlm ] && drlm_ver="$(awk 'BEGIN { FS="=" } /VERSION=/ { print $$2 }' /usr/sbin/drlm) | awk -F. '{printf("%02d%02d%02d\n", $1, $2, $3)}'"
-	if [[ -n "$drlm_ver" ]]; then
+    if [[ -n "$drlm_ver" ]]; then
       if [[ "$drlm_ver" < "020412" ]]; then 
         echo "INFO: Since DRLM 2.4.12 the RSYNC protocol transport is secure by default!!!"
         echo "      Setting insecure transport to all current configuirations using RSYNC."
         echo "      To secure it run [ drlm instclient -c <cli_name> -C ] to each client "
         echo "      and comment out DRLM_BKP_SEC_PROT=no in all required client configurations."
         echo "      New installed clients will be secure by default!"
-	    for cfg in $(find /etc/drlm/clients -type f -name "*.cfg" ! -name "*.drlm.cfg"); do 
-	      PROT=$(grep -v "^#" $cfg | grep DRLM_BKP_PROT=NETFS)
-	      [[ "$PROT" == "" ]] && echo "DRLM_BKP_SEC_PROT=no" >> $cfg
-	    done
-      fi	
+        for cfg in $(find /etc/drlm/clients -type f -name "*.cfg" ! -name "*.drlm.cfg"); do 
+        PROT=$(grep -v "^#" $cfg | grep DRLM_BKP_PROT=NETFS)
+        [[ "$PROT" == "" ]] && echo "DRLM_BKP_SEC_PROT=no" >> $cfg
+        done
+      fi
     else
       echo "INFO: Unable to identify DRLM version, keeping configurations."
     fi

--- a/usr/share/drlm/conf/rear-extra/usr/share/rear/verify/RSYNC/drlm-extra/550_check_remote_backup_archive.sh
+++ b/usr/share/drlm/conf/rear-extra/usr/share/rear/verify/RSYNC/drlm-extra/550_check_remote_backup_archive.sh
@@ -14,9 +14,12 @@ case $(rsync_proto "$BACKUP_URL") in
                 ### drlm-extra:
                 #    Added check for secure transport 
                 #
-                $BACKUP_PROG "$(rsync_remote_full "$BACKUP_URL")/backup" >/dev/null 2>&1 \
-                    || [[ "$DRLM_MANAGED" == "y" ]] && $BACKUP_PROG '-e stunnel /etc/rear/stunnel/drlm.conf' --list-only "$(rsync_remote_full "$BACKUP_URL")/backup" >/dev/null 2>&1 \
-                    || Error "Archive not found on [$(rsync_remote_full "$BACKUP_URL")]"
+                if [[ -z "$RSYNC_PORT" ]]; then
+                    $BACKUP_PROG --list-only "$(rsync_remote_full "$BACKUP_URL")/backup" >/dev/null 2>&1
+                else
+                    $BACKUP_PROG '-e stunnel /etc/rear/stunnel/drlm.conf' --list-only "$(rsync_remote_full "$BACKUP_URL")/backup" >/dev/null 2>&1
+                fi
+                [[ $? -eq 0 ]] || Error "Archive not found on [$(rsync_remote_full "$BACKUP_URL")/backup]"
                 ;;
 esac
 

--- a/usr/share/drlm/www/drlm-api/client.go
+++ b/usr/share/drlm/www/drlm-api/client.go
@@ -458,6 +458,7 @@ func (c *Client) generateDefaultConfig(configName string) string {
 		if drlmBkpProt == "RSYNC" || drlmBkpProt == "\"RSYNC\"" || drlmBkpProt == "" {
 			clientConfig = "export RSYNC_PASSWORD=$(cat /etc/rear/drlm.token)\n"
 			clientConfig += "OUTPUT=RAWDISK\n"
+			clientConfig += "OUTPUT_PREFIX=RAWDISK\n"
 			clientConfig += "RAWDISK_IMAGE_COMPRESSION_COMMAND=\n"
 			clientConfig += "BACKUP=RSYNC\n"
 			clientConfig += "RSYNC_PREFIX=\n"
@@ -471,8 +472,8 @@ func (c *Client) generateDefaultConfig(configName string) string {
 		} else if drlmBkpProt == "NETFS" || drlmBkpProt == "\"NETFS\"" {
 			if drlmBkpProg == "TAR" || drlmBkpProg == "\"TAR\"" || drlmBkpProg == "" {
 				clientConfig = "OUTPUT=RAWDISK\n"
+				clientConfig += "OUTPUT_PREFIX=RAWDISK\n"
 				clientConfig += "RAWDISK_IMAGE_COMPRESSION_COMMAND=\n"
-				clientConfig += "OUTPUT_PREFIX=\n"
 				clientConfig += "BACKUP=NETFS\n"
 				clientConfig += "NETFS_PREFIX=backup\n"
 				clientConfig += "BACKUP_URL=nfs://" + serverIP + configDRLM.StoreDir + "/" + c.Name + "/" + configName + "\n"

--- a/usr/share/drlm/www/drlm-api/client.go
+++ b/usr/share/drlm/www/drlm-api/client.go
@@ -321,6 +321,7 @@ func (c *Client) generateDefaultConfig(configName string) string {
 		if drlmBkpProt == "RSYNC" || drlmBkpProt == "\"RSYNC\"" || drlmBkpProt == "" {
 			clientConfig = "export RSYNC_PASSWORD=$(cat /etc/rear/drlm.token)\n"
 			clientConfig += "OUTPUT=ISO\n"
+			clientConfig += "OUTPUT_PREFIX=ISO\n"
 			clientConfig += "ISO_PREFIX=" + c.Name + "-" + configName + "-DRLM-recover\n"
 			clientConfig += "BACKUP=RSYNC\n"
 			clientConfig += "RSYNC_PREFIX=\n"
@@ -334,7 +335,7 @@ func (c *Client) generateDefaultConfig(configName string) string {
 		} else if drlmBkpProt == "NETFS" || drlmBkpProt == "\"NETFS\"" {
 			if drlmBkpProg == "TAR" || drlmBkpProg == "\"TAR\"" || drlmBkpProg == "" {
 				clientConfig = "OUTPUT=ISO\n"
-				clientConfig += "OUTPUT_PREFIX=\n"
+				clientConfig += "OUTPUT_PREFIX=ISO\n"
 				clientConfig += "ISO_PREFIX=" + c.Name + "-" + configName + "-DRLM-recover\n"
 				clientConfig += "BACKUP=NETFS\n"
 				clientConfig += "NETFS_PREFIX=backup\n"


### PR DESCRIPTION
#### Disaster Recovery Linux Manager (DRLM) Pull Request Template

Please fill in the following items before submitting a new Pull Request:

##### PR details:

* PR type (**Bug Fixing** / **New Feature** / **Enhancement** / **Other?**): Bug Fixing
* Reference to related issue (issue link): 
* Impact (**Low** / **High** / **Critical** / **Urgent**): Low
* Did you test this PR?  yes
* Brief description of the changes in this PR:
Change default OUTPUT_PREFIX of ISO to match PXE style OUTPUT dests.
