### PR TITLE
Change how internal client installation is done

### DIFF
--- a/packaging/debian/postinst
+++ b/packaging/debian/postinst
@@ -105,27 +105,6 @@ case "$1" in
         echo "NFS_SVC_NAME=\"nfs-kernel-server\"" >> /etc/drlm/local.conf
       fi
     fi
-
-    #################
-    # DRLM internal #
-    #################
-    drlm addclient --internal
-    num_jobs=$(echo "SELECT count(*) FROM jobs WHERE clients_id = 0;" | sqlite3 /var/lib/drlm/drlm.sqlite)
-    if [ $num_jobs -eq 0 ]; then
-      drlm addjob -c internal -s $(date -d "tomorrow" +'%Y-%m-%dT08:00') -r 1day
-      drlm addjob -c internal -C iso -s $(date -d "next friday" +'%Y-%m-%dT12:00') -r 1month
-      for job in $(echo "SELECT idjob FROM jobs WHERE clients_id = 0;" | sqlite3 -init <(echo .timeout 2000) /var/lib/drlm/drlm.sqlite); do drlm sched -d -I $job; done
-    fi
-    ((
-       # wait for install to finish
-       while pgrep -x 'dpkg|apt|apt-get' > /dev/null; do sleep 1; done
-       # clear environment
-       eval $(env|grep -E 'DPKG|DEB'|awk -F= '{print "unset "$1}')
-       export DEBIAN_FRONTEND=noninteractive
-       # make sure no one else is locking the dpkg database
-       flock --exclusive --close /var/lib/dpkg/lock \
-       drlm instclient -c internal
-    ) 2>&1 >/dev/null </dev/null &)
     ;;
 
   *)

--- a/packaging/rpm/drlm.spec
+++ b/packaging/rpm/drlm.spec
@@ -250,44 +250,6 @@ fi
 %{__sed} -i "s/TimeoutSec=infinity/TimeoutSec=0/g" /etc/systemd/system/tmp_drlm-stord.service
 %endif
 
-#################
-# DRLM internal #
-#################
-
-# Create internal client to DB
-num_cli=$(echo "SELECT count(*) FROM clients WHERE idclient = 0;" | sqlite3 -init <(echo .timeout 2000) /var/lib/drlm/drlm.sqlite)
-if [ $num_cli -eq 0 ]; then
-  echo "INSERT INTO clients (idclient, cliname, mac, ip, networks_netname, os, rear) VALUES (0, 'internal', '', '127.0.0.1', 'lo', '', '' ); " | sqlite3 -init <(echo .timeout 2000) /var/lib/drlm/drlm.sqlite
-fi
-# Generate client token to improve drlm-api security
-[ -f /etc/drlm/clients/internal.token ] || /usr/bin/tr -dc 'A-Za-z0-9' </dev/urandom | head -c 30 > /etc/drlm/clients/internal.token
-chmod 600 /etc/drlm/clients/internal.token
-# Generate client secrets
-[ -f /etc/drlm/clients/internal.secrets ] || echo "internal:$(cat /etc/drlm/clients/internal.token)" >> /etc/drlm/clients/internal.secrets
-chmod 600 /etc/drlm/clients/internal.secrets
-# Generate default configs
-[ -f /etc/drlm/clients/internal.cfg ] || cp /usr/share/drlm/conf/samples/drlm_internal_config-data_default.cfg /etc/drlm/clients/internal.cfg
-chmod 644 /etc/drlm/clients/internal.cfg
-[ -f /etc/drlm/clients/internal.drlm.cfg] || cp /usr/share/drlm/conf/samples/client_default.drlm.cfg /etc/drlm/clients/internal.drlm.cfg
-chmod 644 /etc/drlm/clients/internal.drlm.cfg
-[ -d /etc/drlm/clients/internal.cfg.d ] || mkdir /etc/drlm/clients/internal.cfg.d
-chmod 755 /etc/drlm/clients/internal.cfg.d
-[ -f /etc/drlm/clients/internal.cfg.d/iso.cfg ] || cp /usr/share/drlm/conf/samples/drlm_internal_full_dr_iso.cfg /etc/drlm/clients/internal.cfg.d/iso.cfg
-chmod 644 /etc/drlm/clients/internal.cfg.d/iso.cfg
-# Set internal network resolution
-sed -i '/127.0.0.1/s/localhost.*/localhost\tinternal/g' /etc/hosts
-# install & configure all client reqs.
-cat /root/.ssh/id_rsa.pub >> /root/.ssh/authorized_keys 
-drlm instclient -c internal
-[ -f /etc/rear/site.conf ] || cp /usr/share/drlm/conf/samples/drlm_internal_full_dr_site_conf.cfg /etc/rear/site.conf
-chmod 600 /etc/rear/site.conf
-num_jobs=$(echo "SELECT count(*) FROM jobs WHERE clients_id = 0;" | sqlite3 -init <(echo .timeout 2000) /var/lib/drlm/drlm.sqlite)
-if [ $num_jobs -eq 0 ]; then
-  drlm addjob -c internal -s $(date -d "tomorrow" +'%Y-%m-%dT08:00') -r 1day
-  drlm addjob -c internal -C iso -s $(date -d "next friday" +'%Y-%m-%dT12:00') -r 1month
-  for job in $(echo "SELECT idjob FROM jobs WHERE clients_id = 0;" | sqlite3 -init <(echo .timeout 2000) /var/lib/drlm/drlm.sqlite); do drlm sched -d -I $job; done
-fi
-
 %preun
 ### Remove certificates
 %{__rm} -f /etc/drlm/cert/drlm.*

--- a/utils/drlm-build-install.sh
+++ b/utils/drlm-build-install.sh
@@ -18,7 +18,7 @@ DRLM_GIT_BRANCH="${DRLM_GIT_BRANCH:-develop}"
 echo "DRLM build & installation script"
 echo "Version: $INSTALLER_VERSION"
 echo "Website: https://drlm.org"
-echo "Git: https://${DRLM_GIT_BASE_URL}${DRLM_GIT_REPOSITORY} -- Branch: ${DRLM_GIT_BRANCH}"
+echo "Git: ${DRLM_GIT_BASE_URL}${DRLM_GIT_REPOSITORY} -- Branch: ${DRLM_GIT_BRANCH}"
 echo ""
 
 

--- a/utils/drlm-build-install.sh
+++ b/utils/drlm-build-install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # "DRLM build & install script"
-INSTALLER_VERSION="202409.02"
+INSTALLER_VERSION="202409.03"
 GOLANG_VERSION="1.21.5"
 # "Author: Pau Roura - Brain Updaters"
 # "Website: https://drlm.org"
@@ -18,7 +18,7 @@ DRLM_GIT_BRANCH="${DRLM_GIT_BRANCH:-develop}"
 echo "DRLM build & installation script"
 echo "Version: $INSTALLER_VERSION"
 echo "Website: https://drlm.org"
-echo "GitHub: https://github.com/brainupdaters/drlm"
+echo "Git: https://${DRLM_GIT_BASE_URL}${DRLM_GIT_REPOSITORY} -- Branch: ${DRLM_GIT_BRANCH}"
 echo ""
 
 

--- a/utils/drlm-build-install.sh
+++ b/utils/drlm-build-install.sh
@@ -139,7 +139,7 @@ drlm_clon_repo() {
     git checkout $DRLM_GIT_BRANCH
 }
 
-# Functino to add DRLM internal client
+# Function to add DRLM internal client
 add_drlm_internal_client() {
     # check if drlm.sqlite exists
     if [ ! -f "/var/lib/drlm/drlm.sqlite" ]; then return; fi


### PR DESCRIPTION
* PR type: **Bug Fixing** and **Enhancement**
* Reference to related issue (issue link): 
* Impact: **High**
* Did you test this PR? Tests done in Debian12
* Brief description of the changes in this PR:

The DRLM inner client build is launched in an unattached shell, causing the installation process to falsely complete. When doing automated processes, the task stops without the client installation process having finished, which causes the client to be incorrectly installed and sometimes leaves the apt corrupted.

On the other hand, in installations where the internal client already exists or in updates, it gives an error that the client already exists and does not complete the installation properly.

This modification proposes to remove the creation of the client from inside the package management and to do the external installation. This simplifies duplicating code, simplifies package management, and solves all the aforementioned problems.