### PR TITLE
change certificate from secp521r1 to secp384r1

### DIFF
--- a/packaging/debian/postinst
+++ b/packaging/debian/postinst
@@ -25,7 +25,7 @@ case "$1" in
     
     # Check if drlm.key has been generated in older installations.
     if [ ! -f /etc/drlm/cert/drlm.key ]; then
-        openssl ecparam -name secp521r1 -genkey -out /etc/drlm/cert/drlm.key
+        openssl ecparam -name secp384r1 -genkey -out /etc/drlm/cert/drlm.key
         openssl req -new -x509 -key /etc/drlm/cert/drlm.key -out /etc/drlm/cert/drlm.crt -days 1825 -subj "/C=ES/ST=CAT/L=GI/O=SA/CN=$(hostname -s)"
     fi
     

--- a/packaging/rpm/drlm.spec
+++ b/packaging/rpm/drlm.spec
@@ -191,7 +191,7 @@ tar --no-same-owner -xzf /var/lib/drlm/store/boot/grub/grub2.04rc1_drlm_i386-pc_
 
 ### If --> is install create keys
 if [ "$1" == "1" ]; then
-openssl ecparam -name secp521r1 -genkey -out /etc/drlm/cert/drlm.key
+openssl ecparam -name secp384r1 -genkey -out /etc/drlm/cert/drlm.key
 openssl req -new -x509 -key /etc/drlm/cert/drlm.key -out /etc/drlm/cert/drlm.crt -days 1825 -subj "/C=ES/ST=CAT/L=GI/O=SA/CN=$(hostname -s)"
 ### Else --> is update save keys
 else


### PR DESCRIPTION
##### PR details:
* PR type: **Bug Fixing** 
* Impact: **High**
* Did you test this PR? yes
* Brief description of the changes in this PR:
   
This PR addresses [briefly describe the issue or feature, e.g., "a compatibility issue with TLS certificates using secp521r1"]. By switching to secp384r1, we improve compatibility with a wider range of clients while maintaining strong security.

Changes
* Updated SSL certificate generation to use secp384r1.
* Ensured compatibility with modern browsers and TLS libraries.
* Improved performance without compromising security.
This change enhances stability and avoids connection errors due to unsupported signature algorithms.
